### PR TITLE
DOCSP-30504: setup rust repo base files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+# Pull Request Info
+
+[PR Reviewing Guidelines](https://github.com/mongodb/docs-rust/blob/master/REVIEWING.md)
+
+JIRA - <https://jira.mongodb.org/browse/DOCSP-NNNNN>
+Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>
+
+## Self-Review Checklist
+
+- [ ] Is this free of any warnings or errors in the RST?
+- [ ] Did you run a spell-check?
+- [ ] Did you run a grammar-check?
+- [ ] Are all the links working?

--- a/.github/workflows/check-autobuilder.yml
+++ b/.github/workflows/check-autobuilder.yml
@@ -1,0 +1,13 @@
+name: Check Autobuilder for Errors
+
+on:
+  pull_request:
+    paths:
+      - "source/**"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cbush/snooty-autobuilder-check@main

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Editor
+.vscode
+.idea
+
+# System
+
+.DS_Store

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,0 +1,44 @@
+# Pull Request Reviewing Guidelines for Rust Driver Documentation
+
+Contributions to the set of documents in this repository can receive reviews from one or both of the following types of reviews:
+
+1. A **copy review**, which focuses on information structure and wording; typically performed by a MongoDB Documentation Team member
+2. A **technical review**, which addresses code snippets and the technical correctness of prose; typically performed by a MongoDB engineer.
+
+See the following sections for reviewer expectations for each type of pull request (PR) review:
+
+## Copy Review
+
+Review the structure, wording, and flow of the information in the PR, and correct it if necessary.
+
+### What to Review
+
+- Wording
+- Page structure
+- Technical content to the extent of the reviewer’s understanding.
+- Whether the PR fulfills the Acceptance Criteria described in the
+  linked JIRA ticket.
+
+### What Not to Review
+
+Nothing is completely off-limits to a copy review of a PR -- if you notice a technical issue, it's best to call it out early.
+Copy reviewers should constrain their reviews to content within the
+scope of the JIRA ticket, or otherwise create tickets to address
+anything unrelated.
+
+## Technical Review
+
+Review the technical accuracy and completeness of a PR and correct it if necessary.
+
+### What to Review
+
+- Code snippets; ensure the code is idiomatic and that all technical claims are correct. e.g. ("To create a `Foo`, use the `Bar.createFoo()` method")
+- Problematic explanations that could trip up users who try to follow the documentation.
+
+### What Not to Review
+
+While we welcome any recommendations on wording and structure, avoid blocking approval based on any copy edits. Please entrust the author to make the writing decisions based on style guidelines and team-specific writing conventions, and to create PRs to address anything they deem outside the technical review scope.
+
+- Wording of sentences, although corrections to technical claims are welcome
+- Structure of the page
+- Any unchanged lines outside the PR unless relevant to the ticket acceptance criteria.

--- a/config/intersphinx.yaml
+++ b/config/intersphinx.yaml
@@ -1,0 +1,7 @@
+name: python
+url: https://docs.python.org/2/
+path: python2.inv
+---
+name: mongodb
+url: https:/www.mongodb.com/docs/manual/
+path: mongodb.inv

--- a/config/redirects
+++ b/config/redirects
@@ -1,6 +1,8 @@
 define: prefix docs/drivers/rust
-define: base https://www.mongodb.com/docs/
+define: base https://www.mongodb.com/${prefix}
 define: versions master
 
-# raw: ${prefix}/${<version or alias>}/<source file> -> ${base}/<destination>
+symlink: current -> master
 
+raw: ${prefix}/ -> ${base}/current/
+raw: ${prefix}/stable -> ${base}/current/

--- a/source/index.txt
+++ b/source/index.txt
@@ -1,8 +1,99 @@
-===========
-Rust Driver
-===========
+=================
+{+driver-long+}
+=================
 
-Your words here. Don't forget to add a toctree!
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
 
-Have a lovely day!
+   View the Source <https://github.com/mongodb/mongo-rust-driver>
 
+..
+   /quick-start
+   /quick-reference
+   /whats-new
+   /usage-examples
+   /fundamentals
+   API Documentation <{+api+}/mongo>
+   /faq
+   /connection-troubleshooting
+   /issues-and-help
+   /compatibility
+
+Introduction
+------------
+
+Welcome to the documentation site for the official {+driver-long+}. 
+You can add the driver to your application to work with MongoDB in Rust. 
+Import it by adding it to your project's ``Cargo.toml`` file or set up a
+runnable project by following our Quick Start guide.
+
+Quick Start
+-----------
+
+.. Learn how to establish a connection to MongoDB Atlas and begin
+.. working with data in the :ref:`rust-quickstart` section.
+
+Quick Reference
+---------------
+
+.. See driver syntax examples for common MongoDB commands in the
+.. :ref:`Quick Reference <rust-quick-reference>` section.
+
+What's New
+----------
+
+.. For a list of new features and changes in each version, see the
+.. :ref:`rust-whats-new` section.
+
+Usage Examples
+--------------
+
+.. For fully runnable code snippets and explanations for common
+.. methods, see :ref:`rust-usage-examples`.
+
+Fundamentals
+------------
+
+.. .. include:: /includes/fundamentals-sections.rst
+
+API
+---
+
+For detailed information about types and methods in the {+driver-long+},
+see the `API documentation <{+api+}>/`__.
+
+FAQ
+---
+
+.. For answers to commonly asked questions about the {+driver-long+}, see
+.. the :ref:`rust-faq` section.
+
+Issues & Help
+-------------
+
+.. Learn how to report bugs, contribute to the driver, and find
+.. additional resources for asking questions in the :ref:`rust-issues-and-help` section.
+
+Compatibility
+-------------
+
+.. For the compatibility charts that show the recommended Go Driver version
+.. for each MongoDB Server version, see :ref:`golang-compatibility`.
+
+Learn
+------
+
+Visit the Developer Hub to learn more about the {+driver-long+}.
+
+Developer Hub
+~~~~~~~~~~~~~
+
+The Developer Hub provides tutorials and social engagement for
+developers.
+
+To learn how to use MongoDB features with the {+driver-short+}, see the
+`How To's and Articles page <https://www.mongodb.com/developer/languages/rust/>`__.
+
+To ask questions and engage in discussions with fellow developers who
+use the {+driver-short+}, see the `forums page <https://www.mongodb.com/community/forums/tag/rust>`__.

--- a/source/index.txt
+++ b/source/index.txt
@@ -1,6 +1,6 @@
-=================
+===================
 {+driver-long+}
-=================
+===================
 
 .. toctree::
    :titlesonly:
@@ -61,7 +61,7 @@ API
 ---
 
 For detailed information about types and methods in the {+driver-long+},
-see the `API documentation <{+api+}>/`__.
+see the `API documentation <{+api+}/>`__.
 
 FAQ
 ---
@@ -79,7 +79,7 @@ Compatibility
 -------------
 
 .. For the compatibility charts that show the recommended Go Driver version
-.. for each MongoDB Server version, see :ref:`golang-compatibility`.
+.. for each MongoDB Server version, see :ref:`rust-compatibility`.
 
 Learn
 ------
@@ -93,7 +93,10 @@ The Developer Hub provides tutorials and social engagement for
 developers.
 
 To learn how to use MongoDB features with the {+driver-short+}, see the
-`How To's and Articles page <https://www.mongodb.com/developer/languages/rust/>`__.
+`Rust page <https://www.mongodb.com/developer/languages/rust/>`__ in the
+MongoDB Developer Center.
 
 To ask questions and engage in discussions with fellow developers who
-use the {+driver-short+}, see the `forums page <https://www.mongodb.com/community/forums/tag/rust>`__.
+use the {+driver-short+}, see the `Rust page
+<https://www.mongodb.com/community/forums/tag/rust>`__ in the MongoDB
+Developer Community forums.

--- a/source/index.txt
+++ b/source/index.txt
@@ -78,7 +78,7 @@ Issues & Help
 Compatibility
 -------------
 
-.. For the compatibility charts that show the recommended Go Driver version
+.. For the compatibility charts that show the recommended {+driver-short+} version
 .. for each MongoDB Server version, see :ref:`rust-compatibility`.
 
 Learn
@@ -97,6 +97,6 @@ To learn how to use MongoDB features with the {+driver-short+}, see the
 MongoDB Developer Center.
 
 To ask questions and engage in discussions with fellow developers who
-use the {+driver-short+}, see the `Rust page
+use the {+driver-short+}, see the `Rust tag
 <https://www.mongodb.com/community/forums/tag/rust>`__ in the MongoDB
-Developer Community forums.
+Community Forums.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-30504
Staging: https://docs-mongodbcom-staging.corp.mongodb.com/rust/docsworker-xlarge/DOCSP-30504-configure-repo/
Build: https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64b193358d53f9c4af22a404

took the configuration files from `docs-golang`