### PR TITLE
DOCSP-39542: delete crud fundamentals

### DIFF
--- a/source/fundamentals/crud/write-operations.txt
+++ b/source/fundamentals/crud/write-operations.txt
@@ -9,15 +9,15 @@ Write Operations
 
    /fundamentals/crud/write-operations/insert
    /fundamentals/crud/write-operations/change
+   /fundamentals/crud/write-operations/delete
 
 ..
-   /fundamentals/crud/write-operations/delete
    /fundamentals/crud/write-operations/arrays
    /fundamentals/crud/write-operations/upsert
 
 - :ref:`rust-insert-guide`
 - :ref:`rust-change-guide`
+- :ref:`rust-delete-guide`
 
-.. - :ref:`rust-delete-guide`
 .. - :ref:`rust-arrays-guide`
 .. - :ref:`rust-upsert-guide`

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -31,14 +31,13 @@ information about its categorization and unit price:
    :copyable: false
    
    { "item": "trowel", "category": "garden", "unit_price": 9.89 },
-   { "item": "blender", "category": "kitchen", "unit_price": 38.49 },
    { "item": "placemat", "category": "kitchen", "unit_price": 3.19 },
    { "item": "watering can", "category": "garden", "unit_price": 11.99 }
 
 Delete Operations
 -----------------
 
-The {driver-short} provides the ``delete_one()`` and ``delete_many()``
+The {+driver-short+} provides the ``delete_one()`` and ``delete_many()``
 methods to perform delete operations.
 
 Parameters
@@ -50,10 +49,8 @@ form criteria for documents to match.
 
 You can also optionally pass a ``DeleteOptions`` type as a parameter to
 either method. You can specify settings in a ``DeleteOptions`` instance
-to configure the delete operation.
-
-To use default values for each setting, specify the value ``None`` as
-the options parameter.
+to configure the delete operation. To use default values for each
+setting, specify the value ``None`` as the options parameter.
 
 The following table describes settings that you can specify in a
 ``DeleteOptions`` instance:
@@ -143,7 +140,7 @@ following parameters:
 
       Deleted documents: 2
 
-.. tip::
+.. note::
 
    If the preceding example used the ``delete_one()`` method instead of
    ``delete_many()`` for the delete operation, the driver would delete

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -23,7 +23,7 @@ Sample Data for Examples
 
 .. TODO decide on structs for crud
 
-The examples in this guide use the following sample documents. Each
+The example in this guide uses the following sample documents. Each
 document represents an item in a store's inventory and contains
 information about its categorization and unit price:
 
@@ -112,8 +112,8 @@ Return Value
 The ``delete_one()`` and ``delete_many()`` methods return a
 ``DeleteResult`` type. This type contains the ``deleted_count`` property,
 which describes the number of documents deleted. If no documents match
-the query filter you provide to the method, the delete operation does
-not remove any documents and the value of ``deleted_count`` is ``0``.
+the query filter you specified, the delete operation does
+not remove any documents, and the value of ``deleted_count`` is ``0``.
 
 delete_many() Example
 ~~~~~~~~~~~~~~~~~~~~~
@@ -144,7 +144,7 @@ following parameters:
 
    If the preceding example used the ``delete_one()`` method instead of
    ``delete_many()`` for the delete operation, the driver would delete
-   the first of the two documents that match the query filter.
+   the first of the two documents that matched the query filter.
 
 Additional Information
 ----------------------

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -1,0 +1,178 @@
+.. _rust-delete-guide:
+
+================
+Delete Documents
+================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+In this guide, you can learn how to remove documents from your MongoDB
+collections using **delete operations**.
+
+.. _rust-delete-sample-data:
+
+Sample Data for Examples
+------------------------
+
+.. TODO decide on structs for crud
+
+The examples in this guide use the following sample documents. Each
+document represents an item in a store's inventory and contains
+information about its categorization and unit price:
+
+.. code-block:: json
+   :copyable: false
+   
+   { "item": "trowel", "category": "garden", "unit_price": 9.89 },
+   { "item": "blender", "category": "kitchen", "unit_price": 38.49 },
+   { "item": "placemat", "category": "kitchen", "unit_price": 3.19 },
+   { "item": "watering can", "category": "garden", "unit_price": 11.99 }
+
+Delete Operations
+-----------------
+
+The {driver-short} provides the ``delete_one()`` and ``delete_many()``
+methods to perform delete operations.
+
+Parameters
+~~~~~~~~~~
+
+The ``delete_one()`` and ``delete_many()`` methods take a query filter
+as a parameter. A query filter consists of the fields and values that
+form criteria for documents to match.
+
+You can also optionally pass a ``DeleteOptions`` type as a parameter to
+either method. You can specify settings in a ``DeleteOptions`` instance
+to configure the delete operation.
+
+To use default values for each setting, specify the value ``None`` as
+the options parameter.
+
+The following table describes settings that you can specify in a
+``DeleteOptions`` instance:
+
+.. list-table::
+   :header-rows: 1
+   :class: compatibility-large
+
+   * - Option
+     - Description
+
+   * - ``collation`` 
+     - | The collation to use when sorting results.
+       | Type: ``Collation``
+       | Default: ``nil``
+
+   * - ``write_concern``
+     - | The write concern for the operation. To learn more about write
+         concerns, see :manual:`Write Concern
+         </reference/write-concern/>` in the Server manual.
+       | Type: ``WriteConcern``
+
+   * - ``hint`` 
+     - | The index to use for the operation. To learn more about
+         indexes, see :manual:`Indexes </indexes/>` in the Server
+         manual. This option is available only when connecting to
+         {+server+} versions 4.4 and later.
+       | Type: ``Hint``
+       | Default: ``nil``
+
+   * - ``let_vars``
+     - | A map of parameters and values. These parameters can be accessed
+         as variables in aggregation expressions. This option is available
+         only when connecting to {+server+} versions 5.0 and later.
+       | Type: ``Document``
+
+   * - ``comment``
+     - | An arbitrary ``Bson`` value tied to the operation to trace
+         it through the database profiler, ``currentOp``, and
+         logs. This option is available only when connecting to
+         {+server+} versions 4.4 and later.
+       | Type: ``Bson``
+
+.. TODO add links to guides for relevant options
+
+The following code shows how to construct an ``DeleteOptions``
+instance and pass it to the ``delete_one()`` method:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/crud/delete.rs
+   :start-after: begin-options
+   :end-before: end-options
+   :language: rust
+   :copyable:
+   :dedent:
+
+Return Value
+~~~~~~~~~~~~
+
+The ``delete_one()`` and ``delete_many()`` methods return a
+``DeleteResult`` type. This type contains the ``deleted_count`` property,
+which describes the number of documents deleted. If no documents match
+the query filter you provide to the method, the delete operation does
+not remove any documents and the value of ``deleted_count`` is ``0``.
+
+delete_many() Example
+~~~~~~~~~~~~~~~~~~~~~
+
+This example shows how to call the ``delete_many()`` method with the
+following parameters:
+
+- A query filter that matches documents where the value of ``category``
+  is ``"garden"``
+- A ``DeleteOptions`` instance that uses the ``_id_`` index as the hint
+  for the delete operation
+
+.. io-code-block::
+
+   .. input:: /includes/fundamentals/code-snippets/crud/delete.rs
+      :start-after: begin-delete
+      :end-before: end-delete
+      :language: rust
+      :dedent:
+
+   .. output::
+      :language: console
+      :visible: false
+
+      Deleted documents: 2
+
+.. tip::
+
+   If the preceding example used the ``delete_one()`` method instead of
+   ``delete_many()`` for the delete operation, the driver would delete
+   the first of the two documents that match the query filter.
+
+Additional Information
+----------------------
+
+.. TODO For runnable examples of the delete operations, see the following usage
+.. examples:
+
+.. - :ref:`rust-delete-one`
+.. - :ref:`rust-delete-many`
+
+.. TODO To learn more about performing the operations mentioned, see the
+.. following guides:
+
+.. - :ref:`rust-query-guide`
+.. - :ref:`rust-indexes`.
+.. - :ref:`rust-collations`.
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+To learn more about any of the methods or types discussed in this
+guide, see the following API Documentation:
+
+- `delete_one() <{+api+}/struct.Collection.html#method.delete_one>`__
+- `delete_many() <{+api+}/struct.Collection.html#method.delete_many>`__
+- `DeleteOptions <{+api+}/options/struct.DeleteOptions.html>`__
+- `Hint <{+api+}/options/enum.Hint.html>`__
+- `DeleteResult <{+api+}/results/struct.DeleteResult.html>`__

--- a/source/includes/fundamentals/code-snippets/crud/delete.rs
+++ b/source/includes/fundamentals/code-snippets/crud/delete.rs
@@ -13,6 +13,7 @@ async fn main() -> mongodb::error::Result<()> {
     let filter = doc! { "category": "garden" };
     let hint = Hint::Name("_id_".to_string());
     let opts: DeleteOptions = DeleteOptions::builder().hint(hint).build();
+
     let res = my_coll.delete_many(filter, opts).await?;
     println!("Deleted documents: {}", res.deleted_count);
     // end-delete

--- a/source/includes/fundamentals/code-snippets/crud/delete.rs
+++ b/source/includes/fundamentals/code-snippets/crud/delete.rs
@@ -1,0 +1,26 @@
+use bson::{ Document, bson };
+use mongodb::{ bson::doc, options::{ DeleteOptions, Hint }, Client, Collection };
+use std::{ env };
+
+#[tokio::main]
+async fn main() -> mongodb::error::Result<()> {
+    let uri = "<connection string>";
+    let client = Client::with_uri_str(uri).await?;
+
+    let my_coll: Collection<Document> = client.database("db").collection("inventory");
+
+    // begin-delete
+    let filter = doc! { "category": "garden" };
+    let hint = Hint::Name("_id_".to_string());
+    let opts: DeleteOptions = DeleteOptions::builder().hint(hint).build();
+    let res = my_coll.delete_many(filter, opts).await?;
+    println!("Deleted documents: {}", res.deleted_count);
+    // end-delete
+
+    // begin-options
+    let opts: DeleteOptions = DeleteOptions::builder().comment(bson!("hello!")).build();
+    let _res = my_coll.delete_one(filter, opts).await?;
+    // end-options
+
+    Ok(())
+}


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-rust/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-39542>
Staging - 
https://docs-mongodbcom-staging.corp.mongodb.com/rust/docsworker-xlarge/DOCSP-39542-delete/fundamentals/crud/write-operations/delete/
https://docs-mongodbcom-staging.corp.mongodb.com/rust/docsworker-xlarge/DOCSP-39542-delete/fundamentals/crud/write-operations/#std-label-rust-crud-write-operations

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
