### PR TITLE
DOCSP-30562: operation error handling

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -10,6 +10,7 @@
    /quick-reference
    /fundamentals
    API Documentation <{+api+}/>
+   /op-error-handling
    /issues-and-help
    /compatibility
    View the Source <https://github.com/mongodb/mongo-rust-driver>
@@ -68,6 +69,12 @@ FAQ
 
 .. For answers to commonly asked questions about the {+driver-long+}, see
 .. the :ref:`rust-faq` section.
+
+Operation Error Handling
+------------------------
+
+To learn about errors you might encounter when using the {+driver-long+}
+to perform MongoDB operations, see :ref:`rust-operation-errors`.
 
 Issues & Help
 -------------

--- a/source/op-error-handling.txt
+++ b/source/op-error-handling.txt
@@ -38,9 +38,10 @@ appropriate actions to either handle them or correct the error-causing code.
 Error Type
 ----------
 
-Most of the exceptions that the driver generates when performing operations
-are of the `Error <{+api+}/error/struct.Error.html>`__ type. The
-``Error`` type contains the ``kind`` field, which describes the type of
+If the driver encounters an error while performing an operation, it
+returns an error of the `Error <{+api+}/error/struct.Error.html>`__ type.
+
+The ``Error`` type contains the ``kind`` field, which describes the type of
 error that occurred. The ``kind`` field has a value of enum `ErrorKind
 <{+api+}/error/enum.ErrorKind.html>`__. The ``ErrorKind`` enum has
 variants for different kinds of errors, including the following:

--- a/source/op-error-handling.txt
+++ b/source/op-error-handling.txt
@@ -14,7 +14,9 @@ Overview
 --------
 
 This page describes errors you might encounter when
-using the {+driver-long+} to perform MongoDB operations.
+using the {+driver-long+} to perform MongoDB operations. Once you
+understand the types of errors that the driver raises, you can take
+appropriate actions to either handle them or correct the error-causing code.
 
 .. note::
 
@@ -36,13 +38,18 @@ using the {+driver-long+} to perform MongoDB operations.
 Error Type
 ----------
 
-Most of the exceptions that the driver throws when executing operations
+Most of the exceptions that the driver generates when performing operations
 are of the `Error <{+api+}/error/struct.Error.html>`__ type. The
-``Error`` instance that an operation
-returns contains the ``kind`` field, which describes the type of error
-that occurred. The ``kind`` field has a value of type `ErrorKind
-<{+api+}/error/enum.ErrorKind.html>`__, which has many variants for
-different kinds of errors.
+``Error`` type contains the ``kind`` field, which describes the type of
+error that occurred. The ``kind`` field has a value of enum `ErrorKind
+<{+api+}/error/enum.ErrorKind.html>`__. The ``ErrorKind`` enum has
+variants for different kinds of errors, including the following:
+
+- ``InvalidArgument``: you provided an invalid argument to a method
+- ``Authentication``: the driver encountered an error during authentication
+- ``ServerSelection``: the client couldn't select a server for the operation
+- ``Write``: an error occurred during a write operation
+- ``Transaction``: an error occurred during a transaction
 
 For example, if you attempt to perform an insert operation that
 duplicates an ``_id`` field value that is already in the collection,
@@ -58,14 +65,14 @@ message:
    {}, wire_version: None, source: None }
 
 In the preceding error message, the value of the ``kind`` field is
-``Write``, which applies when an error occurs when
-you try to execute a write operation.
+``Write``. To learn more about this type of error, see the :ref:`Write
+Error Types <rust-error-write-errors>` section of this guide.
 
 Connection Errors
 -----------------
 
-You might successfully connect to a MongoDB server, but the connection
-pool might be cleared due to a concurrent operation error. In this
+A concurrent operation error might clear the connection pool,
+interrupting your connection to the server. In this
 situation, the driver raises an ``Error`` type where the value of the
 ``kind`` field is ``ConnectionPoolCleared``. The error message describes
 the reason that the concurrent operation failed.
@@ -82,13 +89,15 @@ following error message:
    I/O error: timed out, labels: {}" }, labels: {"RetryableWriteError"},
    wire_version: None, source: None }
 
-This label indicates that the error is the error is write-retryable.
+This label indicates that the error is write-retryable.
+
+.. _rust-error-write-errors:
 
 Write Error Types
 -----------------
 
 When the driver experiences an error while performing a write operation,
-it raises an error where the ``kind`` field value is ``Write``.
+it raises an ``Error`` instance with a ``kind`` field value of ``Write``.
 The body of the ``Write`` variant is the enum `WriteFailure
 <{+api+}/error/enum.WriteFailure.html>`__, which
 takes a value of type `WriteError <{+api+}/error/struct.WriteError.html>`__ or
@@ -97,18 +106,18 @@ takes a value of type `WriteError <{+api+}/error/struct.WriteError.html>`__ or
 Write Concern Error
 ~~~~~~~~~~~~~~~~~~~
 
-The driver raises a ``WriteConcernError`` error when you execute a write
+The driver raises a ``WriteConcernError`` error when you perform a write
 operation and the driver cannot satisfy the specified write concern. For
 example, if you specify a write concern of ``majority`` for
-operations on a replica set with three nodes, the driver would return
-this error if the write operation propagated only to one node.
+operations on a replica set with three nodes, the driver returns
+this error if the write operation propagates only to one node.
 
 Write Error
 ~~~~~~~~~~~
 
 The driver raises a ``WriteError`` error for any errors that it
 encounters when performing a write operation that are not related to
-satisfying the write concern. Because are numerous causes for this
+satisfying the write concern. Because there are many causes for this
 error, the ``WriteError`` type contains fields that describe the type of
 write error and reason for the error.
 

--- a/source/op-error-handling.txt
+++ b/source/op-error-handling.txt
@@ -50,6 +50,7 @@ the driver returns an ``Error`` instance and prints the following error
 message:
 
 .. code-block:: none
+   :copyable: false
 
    Error: Error { kind: Write(WriteError(WriteError { code: 11000,
    code_name: None, message: "E11000 duplicate key error collection:
@@ -74,6 +75,7 @@ add a ``RetryableWriteError`` label to the error, as shown in the
 following error message:
 
 .. code-block:: none
+   :copyable: false
 
    Error { kind: ConnectionPoolCleared { message: "Connection pool for
    localhost:27017 cleared because another operation failed with: Kind:
@@ -118,6 +120,7 @@ attempt to insert a document where the value of ``quantity`` is
 ``"three"``, the driver prints the following error message:
 
 .. code-block:: none
+   :copyable: false
 
    Error: Error { kind: Write(WriteError(WriteError { code: 121, code_name:
    None, message: "Document failed validation", details:

--- a/source/op-error-handling.txt
+++ b/source/op-error-handling.txt
@@ -88,8 +88,8 @@ following error message:
 
 .. code-block:: none
    :copyable: false
-   :emphasize-lines: 1
-
+   :emphasize-lines: 3
+   
    Error { kind: ConnectionPoolCleared { message: "Connection pool for
    localhost:27017 cleared because another operation failed with: Kind:
    I/O error: timed out, labels: {}" }, labels: {"RetryableWriteError"},

--- a/source/op-error-handling.txt
+++ b/source/op-error-handling.txt
@@ -15,7 +15,7 @@ Overview
 
 This page describes errors you might encounter when
 using the {+driver-long+} to perform MongoDB operations. Once you
-understand the types of errors that the driver raises, you can take
+understand the types of operation errors that the driver raises, you can take
 appropriate actions to either handle them or correct the error-causing code.
 
 .. note::
@@ -83,13 +83,15 @@ following error message:
 
 .. code-block:: none
    :copyable: false
+   :emphasize-lines: 1
 
    Error { kind: ConnectionPoolCleared { message: "Connection pool for
    localhost:27017 cleared because another operation failed with: Kind:
    I/O error: timed out, labels: {}" }, labels: {"RetryableWriteError"},
    wire_version: None, source: None }
 
-This label indicates that the error is write-retryable.
+This label indicates that the error is write-retryable, which means that
+the driver makes one retry attempt.
 
 .. _rust-error-write-errors:
 
@@ -111,6 +113,9 @@ operation and the driver cannot satisfy the specified write concern. For
 example, if you specify a write concern of ``majority`` for
 operations on a replica set with three nodes, the driver returns
 this error if the write operation propagates only to one node.
+
+To learn more about write concerns, see :manual:`Write Concern
+</reference/write-concern/>` in the Server manual.
 
 Write Error
 ~~~~~~~~~~~
@@ -141,12 +146,8 @@ attempt to insert a document where the value of ``quantity`` is
 
 In the preceding error message, the ``message`` field describes the
 reason for the error, and the ``details`` field provides specific
-details about the failing operation.
-
-Additional Information
-----------------------
-
-To learn more about write concerns, see :manual:`Write Concern
-</reference/write-concern/>` in the Server manual.
-     
+details about the failing operation. To address this error, you must
+either revise the document to adhere to the schema validation rules or
+bypass validation.
+  
 .. TODO To learn more about schema validation, see <link>.

--- a/source/op-error-handling.txt
+++ b/source/op-error-handling.txt
@@ -24,7 +24,7 @@ using the {+driver-long+} to perform MongoDB operations.
 
    - The :ref:`Issues & Help <rust-issues-and-help>` page, which has
      information about reporting bugs, contributing to the driver, and 
-     finding additional resources
+     finding more resources
    - The `MongoDB Community Forums <https://community.mongodb.com>`__ for
      questions, discussions, or general technical support
 

--- a/source/op-error-handling.txt
+++ b/source/op-error-handling.txt
@@ -1,0 +1,140 @@
+.. _rust-operation-errors:
+
+========================
+Operation Error Handling
+========================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+This page describes errors you might encounter when
+using the {+driver-long+} to perform MongoDB operations.
+
+.. note::
+
+   This page addresses only operation error handling. If you encounter
+   any other issues with MongoDB or the driver, visit the following
+   resources:
+
+   - The :ref:`Issues & Help <rust-issues-and-help>` page, which has
+     information about reporting bugs, contributing to the driver, and 
+     finding additional resources
+   - The `MongoDB Community Forums <https://community.mongodb.com>`__ for
+     questions, discussions, or general technical support
+
+   ..
+     - The :ref:`Frequently Asked Questions (FAQ) <golang-faq>` for the
+       {+driver-short+}
+     - :ref:`rust-connection-troubleshooting`
+
+Error Type
+----------
+
+Most of the exceptions that the driver throws when executing operations
+are of the `Error <{+api+}/error/struct.Error.html>`__ type. The
+``Error`` instance that an operation
+returns contains the ``kind`` field, which describes the type of error
+that occurred. The ``kind`` field has a value of type `ErrorKind
+<{+api+}/error/enum.ErrorKind.html>`__, which has many variants for
+different kinds of errors.
+
+For example, if you attempt to perform an insert operation that
+duplicates an ``_id`` field value that is already in the collection,
+the driver returns an ``Error`` instance and prints the following error
+message:
+
+.. code-block:: none
+
+   Error: Error { kind: Write(WriteError(WriteError { code: 11000,
+   code_name: None, message: "E11000 duplicate key error collection:
+   db.test_coll index: _id_ dup key: { _id: 1 }", details: None })), labels:
+   {}, wire_version: None, source: None }
+
+In the preceding error message, the value of the ``kind`` field is
+``Write``, which applies when an error occurs when
+you try to execute a write operation.
+
+Connection Errors
+-----------------
+
+You might successfully connect to a MongoDB server, but the connection
+pool might be cleared due to a concurrent operation error. In this
+situation, the driver raises an ``Error`` type where the value of the
+``kind`` field is ``ConnectionPoolCleared``. The error message describes
+the reason that the concurrent operation failed.
+
+Depending on the circumstances that produce the error, the driver may
+add a ``RetryableWriteError`` label to the error, as shown in the
+following error message:
+
+.. code-block:: none
+
+   Error { kind: ConnectionPoolCleared { message: "Connection pool for
+   localhost:27017 cleared because another operation failed with: Kind:
+   I/O error: timed out, labels: {}" }, labels: {"RetryableWriteError"},
+   wire_version: None, source: None }
+
+This label indicates that the error is the error is write-retryable.
+
+Write Error Types
+-----------------
+
+When the driver experiences an error while performing a write operation,
+it raises an error where the ``kind`` field value is ``Write``.
+The body of the ``Write`` variant is the enum `WriteFailure
+<{+api+}/error/enum.WriteFailure.html>`__, which
+takes a value of type `WriteError <{+api+}/error/struct.WriteError.html>`__ or
+`WriteConcernError <{+api+}/error/struct.WriteConcernError.html>`__.
+
+Write Concern Error
+~~~~~~~~~~~~~~~~~~~
+
+The driver raises a ``WriteConcernError`` error when you execute a write
+operation and the driver cannot satisfy the specified write concern. For
+example, if you specify a write concern of ``majority`` for
+operations on a replica set with three nodes, the driver would return
+this error if the write operation propagated only to one node.
+
+Write Error
+~~~~~~~~~~~
+
+The driver raises a ``WriteError`` error for any errors that it
+encounters when performing a write operation that are not related to
+satisfying the write concern. Because are numerous causes for this
+error, the ``WriteError`` type contains fields that describe the type of
+write error and reason for the error.
+
+For example, the driver raises a ``WriteError`` error if you attempt to
+insert a document into a collection that violates the collection's
+schema validation rules. Suppose the collection has a rule where the
+value of the ``quantity`` field must be an ``int`` type. If you
+attempt to insert a document where the value of ``quantity`` is
+``"three"``, the driver prints the following error message:
+
+.. code-block:: none
+
+   Error: Error { kind: Write(WriteError(WriteError { code: 121, code_name:
+   None, message: "Document failed validation", details:
+   Some(Document({"failingDocumentId": Int32(1), "details":
+   Document({"operatorName": String("$jsonSchema"), "title":
+   String("Numerical Validation"), "schemaRulesNotSatisfied":
+   Array(...)})})) })), labels: {},
+   wire_version: None, source: None }
+
+In the preceding error message, the ``message`` field describes the
+reason for the error, and the ``details`` field provides specific
+details about the failing operation.
+
+Additional Information
+----------------------
+
+To learn more about write concerns, see :manual:`Write Concern
+</reference/write-concern/>` in the Server manual.
+     
+.. TODO To learn more about schema validation, see <link>.

--- a/source/op-error-handling.txt
+++ b/source/op-error-handling.txt
@@ -58,6 +58,7 @@ message:
 
 .. code-block:: none
    :copyable: false
+   :emphasize-lines: 1
 
    Error: Error { kind: Write(WriteError(WriteError { code: 11000,
    code_name: None, message: "E11000 duplicate key error collection:
@@ -76,6 +77,10 @@ interrupting your connection to the server. In this
 situation, the driver raises an ``Error`` type where the value of the
 ``kind`` field is ``ConnectionPoolCleared``. The error message describes
 the reason that the concurrent operation failed.
+
+To learn how to adjust your connection pool to address this error, see
+:manual:`Tuning Your Connection Pool Settings
+</tutorial/connection-pool-performance-tuning/>` in the Server manual.
 
 Depending on the circumstances that produce the error, the driver may
 add a ``RetryableWriteError`` label to the error, as shown in the
@@ -135,6 +140,7 @@ attempt to insert a document where the value of ``quantity`` is
 
 .. code-block:: none
    :copyable: false
+   :emphasize-lines: 2-3
 
    Error: Error { kind: Write(WriteError(WriteError { code: 121, code_name:
    None, message: "Document failed validation", details:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-rust/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-30562>
Staging:
- https://preview-mongodbrustagir.gatsbyjs.io/rust/DOCSP-30562-ops-error-handling/op-error-handling/
- https://preview-mongodbrustagir.gatsbyjs.io/rust/DOCSP-30562-ops-error-handling/#operation-error-handling

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST? > ignore the error, it is being handled in a different PR
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?

had to manually run vale - fixed issues:
✔ 0 errors, 0 warnings and 0 suggestions in 1 file.
