### PR TITLE
DOCSP-33935: fix client api link on auth page

### DIFF
--- a/source/fundamentals/authentication.txt
+++ b/source/fundamentals/authentication.txt
@@ -23,7 +23,7 @@ between the driver and the server.
    To learn how to authenticate to MongoDB by using a Lightweight
    Directory Access Protocol (LDAP) server, see the guide on
    :ref:`rust-enterprise-auth`.
-   
+
    To learn more about connecting to a MongoDB deployment, see the
    :ref:`rust-connect-to-mongodb`.
 
@@ -68,8 +68,8 @@ MongoDB supports the following SCRAM-based authentication mechanisms:
    If you do not specify an authentication mechanism, the server
    attempts to validate credentials by using the default authentication
    mechanism, a SCRAM-based mechanism that varies depending on the
-   version of the server that you are connecting to. 
-   
+   version of the server that you are connecting to.
+
    The ``SCRAM-SHA-256`` mechanism is the default authentication
    mechanism for MongoDB Server versions 4.0 and later.
 
@@ -80,7 +80,7 @@ MongoDB supports the following SCRAM-based authentication mechanisms:
    - ``username``: Your username
    - ``password``: Your password
    - ``db``: The authentication database associated with the user
-   
+
    .. literalinclude:: /includes/fundamentals/code-snippets/auth.rs
       :language: rust
       :dedent:
@@ -144,7 +144,7 @@ feature flag to your ``mongodb`` dependency in your project's
 
 .. code-block:: none
    :emphasize-lines: 3
-   
+
    [dependencies.mongodb]
    version = "{+version+}"
    features = [ "aws-auth", ... ]
@@ -154,7 +154,7 @@ feature flag to your ``mongodb`` dependency in your project's
    To use the ``MONGODB-AWS`` authentication mechanism in the
    {+driver-short+}, your application must meet the following
    requirements:
-   
+
    - You are connected to MongoDB Server version 4.4 or later.
    - You are using the ``tokio`` asynchronous runtime.
 
@@ -189,7 +189,7 @@ the corresponding ways.
       ``mechanism`` field of your ``Credential`` struct to
       ``AuthMechanism::MongoDbAws``. This example specifies the
       authentication mechanism by using the following placeholders:
-      
+
       - ``access key ID``: Your AWS access key ID
       - ``secret access key``: Your AWS secret access key
       - ``db``: The authentication database associated with the user
@@ -253,7 +253,7 @@ the corresponding ways.
       .. code-block:: bash
 
          export AWS_WEB_IDENTITY_TOKEN_FILE=<absolute path to OIDC token file>
-      
+
       Set the ``mechanism`` option in your
       ``Credential`` struct to ``AuthMechanism::MongoDbAws``. The driver
       reads your AWS IAM credentials from the token file.
@@ -286,7 +286,7 @@ To specify the ``MONGODB-X509`` authentication mechanism, set the
 ``mechanism`` field of your ``Credential`` struct to
 ``AuthMechanism::MongoDbX509``. This example specifies the
 authentication mechanism by using the following placeholders:
-      
+
 - ``path to CA certificate``: The filepath for your CA file
 - ``path to private client key``: The filepath for your certificate key file
 - ``db``: The authentication database associated with the user
@@ -320,6 +320,6 @@ guide, see the following API documentation:
 
 - `Credential <{+api+}/options/struct.Credential.html>`__
 - `ClientOptions <{+api+}/options/struct.ClientOptions.html>`__
-- `Client <{+api+}/options/struct.Client.html>`__
+- `Client <{+api+}/struct.Client.html>`__
 - `Client::with_options() <{+api+}/struct.Client.html#method.with_options>`__
 - `ClientOptions::parse() <{+api+}/options/struct.ClientOptions.html#method.parse>`__


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-rust/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-33935>
Staging - https://preview-mongodbcchomongodb.gatsbyjs.io/rust/DOCSP-33935-fix-client-api-link/fundamentals/authentication/#api-documentation

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
