### PR TITLE
DOCSP-31343 added facets.toml files to docs-rust

### DIFF
--- a/source/facets.toml
+++ b/source/facets.toml
@@ -1,0 +1,7 @@
+[[facets]]
+category = "target_product"
+value = "drivers"
+
+[[facets]]
+category = "programming_language"
+value = "rust"

--- a/source/quick-start/facets.toml
+++ b/source/quick-start/facets.toml
@@ -1,0 +1,3 @@
+[[facets]]
+category = "genre"
+value = "tutorial"

--- a/source/usage-examples/facets.toml
+++ b/source/usage-examples/facets.toml
@@ -1,0 +1,3 @@
+[[facets]]
+category = "genre"
+value = "tutorial"


### PR DESCRIPTION
# Pull Request Info
Hey @ccho-mongodb - here's the facets.toml files for the Rust Driver.  There are three because the /source/ directory was missing from the original facets.csv file.

JIRA - <https://jira.mongodb.org/browse/DOCSP-31343>
Staging - <https://preview-mongodbsarahemlin.gatsbyjs.io/rust/DOCSP-31343/>

