### PR TITLE
DOCSP-31470: describe connection pool in perf page

### DIFF
--- a/source/fundamentals/performance.txt
+++ b/source/fundamentals/performance.txt
@@ -71,7 +71,15 @@ Connection Pool
 
 Every ``Client`` instance has a built-in connection pool for each server
 in your MongoDB topology. Connection pools open sockets on demand to
-support concurrent requests to MongoDB in your application.
+support concurrent requests to MongoDB in your application. You can
+tune the connection pool to best fit the needs of your application
+and optimize performance.
+
+.. tip::
+   
+   To learn more about configuring a connection pool, see
+   :manual:`Tuning Your Connection Pool Settings
+   <tutorial/connection-pool-performance-tuning/>` in the Server manual.
 
 The maximum size of each connection pool is set by the ``max_pool_size``
 option, which defaults to ``10``. If the number of in-use connections to
@@ -87,11 +95,6 @@ monitoring sockets. If the application uses the default setting for
 there can be at most ``16`` total connections in the connection pool. If the
 application uses a read preference to query the secondary nodes, those
 connection pools grow and there can be ``36`` total connections.
-
-.. tip::
-
-   To learn more about read preference modes, see :manual:`Read
-   Preference </core/read-preference/>` in the Server manual.
 
 To support high numbers of concurrent MongoDB requests
 within one process, you can increase the value of the ``max_pool_size``

--- a/source/fundamentals/performance.txt
+++ b/source/fundamentals/performance.txt
@@ -115,7 +115,7 @@ parallel at any time. For example, if the value of ``max_connecting`` is
 check out a connection succeeds only when one of the following cases occurs:
 
 - The connection pool finishes creating a connection and the number of
-  connections in the pool is less than the value of ``max_pool_size``.
+  connections in the pool is less than or equal to the value of ``max_pool_size``.
 - An existing connection is checked back into the pool.
 - The driver's ability to reuse existing connections improves due to
   rate limits on connection creation.

--- a/source/fundamentals/performance.txt
+++ b/source/fundamentals/performance.txt
@@ -4,6 +4,13 @@
 Performance Considerations
 ==========================
 
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta::
+   :keywords: code example, optimization, speed, memory
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -19,6 +26,24 @@ instance automatically handles most aspects of connection, such as
 discovering server topology, monitoring your connection, and maintaining
 an internal connection pool. This guide describes best practices for
 configuring and using your ``Client`` instance.
+
+This guide includes the following sections:
+
+- :ref:`Client Lifecycle <rust-performance-client-lifecycle>` describes
+  best practices for creating and managing a ``Client`` instance
+
+- :ref:`Connection Pool Management <rust-performance-pool>` describes
+  how connection pooling works in the driver
+
+- :ref:`Parallelism <rust-performance-parallelism>` provides sample code
+  for running parallel, asynchronous tasks
+
+- :ref:`Runtime <rust-performance-runtime>` describes how to manage
+  runtimes by using functionalities of the ``tokio`` and ``async_std`` crates
+
+- :ref:`Additional Information <rust-perf-addtl-info>`
+  provides links to resources and API documentation for types
+  and methods mentioned in this guide
 
 .. _rust-performance-client-lifecycle:
 
@@ -38,6 +63,78 @@ by using the same client:
 .. literalinclude:: /includes/fundamentals/code-snippets/performance.rs
    :language: rust
    :dedent:
+
+.. _rust-performance-pool:
+
+Connection Pool Management
+--------------------------
+
+Every ``Client`` instance has a built-in connection pool for each server
+in your MongoDB topology. Connection pools open sockets on demand to
+support concurrent requests to MongoDB in your application.
+
+The maximum size of each connection pool is set by the ``max_pool_size``
+option, which defaults to ``10``. If the number of in-use connections to
+a server reaches the value of ``max_pool_size``, the next request to
+that server will wait until a connection becomes available.
+
+In addition to the sockets needed to support your application's requests,
+each ``Client`` instance opens two additional sockets per server
+in your MongoDB topology for monitoring the server's state.
+For example, a client connected to a three-node replica set opens six
+monitoring sockets. If the application uses the default setting for
+``max_pool_size`` and only queries the primary (default) node, then
+there can be at most ``16`` total connections in the connection pool. If the
+application uses a read preference to query the secondary nodes, those
+connection pools grow and there can be ``36`` total connections.
+
+.. tip::
+
+   To learn more about read preference modes, see :manual:`Read
+   Preference </core/read-preference/>` in the Server manual.
+
+To support high numbers of concurrent MongoDB requests
+within one process, you can increase the value of the ``max_pool_size``
+option.
+
+Connection pools are rate-limited. The ``max_connecting`` option
+determines the number of connections that the pool can create in
+parallel at any time. For example, if the value of ``max_connecting`` is
+``2``, as is by default, the third request that attempts to concurrently
+check out a connection succeeds only when one of the following cases occurs:
+
+- The connection pool finishes creating a connection and there are fewer
+  than ``max_pool_size`` connections in the pool.
+- An existing connection is checked back into the pool.
+- The driver's ability to reuse existing connections improves due to
+  rate-limits on connection creation.
+
+You can set the minimum number of concurrent connections to
+each server with the ``min_pool_size`` option, which defaults to ``0``.
+The driver initializes the connection pool with this number of sockets. If
+sockets are closed and the total number of sockets, both in use and
+idle, to drop below the minimum, the connection pool opens more sockets until the
+minimum is reached.
+
+You can set the maximum amount of time that a connection can
+remain idle in the pool by setting the ``max_idle_time`` option.
+Once a connection has been idle for ``max_idle_time``, the connection
+pool removes and replaces it. This option defaults to ``0``, or no limit.
+
+When the ``Client::shutdown()`` method is called at any point in your
+application, the driver closes all idle sockets and closes all sockets
+that are in use as they are returned to the pool. Calling ``Client::shutdown()``
+closes only inactive sockets, so you cannot interrupt or terminate
+any ongoing operations by using this method. The driver closes these
+sockets only when the process completes.
+
+The default configuration for a ``Client`` works for most applications.
+You can create a client with default connection settings by using the
+following instantiation code:
+
+.. code-block:: rust
+   
+   let client = Client::with_uri_str("<connection string>").await?;
 
 .. _rust-performance-parallelism:
 
@@ -87,6 +184,8 @@ ensuring that there are no unintended interactions between runtimes:
 .. literalinclude:: /includes/fundamentals/code-snippets/performance-new-client.rs
    :language: rust
    :dedent:
+
+.. _rust-perf-addtl-info:
 
 Additional Information
 ----------------------

--- a/source/fundamentals/performance.txt
+++ b/source/fundamentals/performance.txt
@@ -95,7 +95,15 @@ connection pools grow and there can be ``36`` total connections.
 
 To support high numbers of concurrent MongoDB requests
 within one process, you can increase the value of the ``max_pool_size``
-option.
+option. The following code demonstrates how to instantiate a ``Client``
+while specifying a value for ``max_pool_size``:
+
+.. code-block:: rust
+   
+   let mut client_options = ClientOptions::parse("<connection string>").await?;
+   client_options.max_pool_size = Some(20);
+
+   let client = Client::with_options(client_options)?;
 
 Connection pools are rate-limited. The ``max_connecting`` option
 determines the number of connections that the pool can create in
@@ -200,6 +208,7 @@ API Documentation
 ~~~~~~~~~~~~~~~~~
 
 - `Client() <{+api+}/struct.Client.html>`__
+- `ClientOptions <{+api+}/options/struct.ClientOptions.html>`__
 - `spawn() <https://docs.rs/tokio/latest/tokio/task/fn.spawn.html>`__ in
   the ``tokio::task`` module
 - `tokio::runtime <https://docs.rs/tokio/latest/tokio/runtime/index.html>`__ module

--- a/source/fundamentals/performance.txt
+++ b/source/fundamentals/performance.txt
@@ -79,7 +79,7 @@ a server reaches the value of ``max_pool_size``, the next request to
 that server will wait until a connection becomes available.
 
 In addition to the sockets needed to support your application's requests,
-each ``Client`` instance opens two additional sockets per server
+each ``Client`` instance opens two more sockets per server
 in your MongoDB topology for monitoring the server's state.
 For example, a client connected to a three-node replica set opens six
 monitoring sockets. If the application uses the default setting for
@@ -137,8 +137,8 @@ any ongoing operations by using this method. The driver closes these
 sockets only when the process completes.
 
 The default configuration for a ``Client`` works for most applications.
-You can create a client with default connection settings by using the
-following instantiation code:
+The following code shows how to create a client with default connection
+settings:
 
 .. code-block:: rust
    

--- a/source/fundamentals/performance.txt
+++ b/source/fundamentals/performance.txt
@@ -32,7 +32,7 @@ This guide includes the following sections:
 - :ref:`Client Lifecycle <rust-performance-client-lifecycle>` describes
   best practices for creating and managing a ``Client`` instance
 
-- :ref:`Connection Pool Management <rust-performance-pool>` describes
+- :ref:`Connection Pool <rust-performance-pool>` describes
   how connection pooling works in the driver
 
 - :ref:`Parallelism <rust-performance-parallelism>` provides sample code
@@ -66,8 +66,8 @@ by using the same client:
 
 .. _rust-performance-pool:
 
-Connection Pool Management
---------------------------
+Connection Pool
+---------------
 
 Every ``Client`` instance has a built-in connection pool for each server
 in your MongoDB topology. Connection pools open sockets on demand to

--- a/source/fundamentals/performance.txt
+++ b/source/fundamentals/performance.txt
@@ -79,7 +79,7 @@ and optimize performance.
    
    To learn more about configuring a connection pool, see
    :manual:`Tuning Your Connection Pool Settings
-   <tutorial/connection-pool-performance-tuning/>` in the Server manual.
+   </tutorial/connection-pool-performance-tuning/>` in the Server manual.
 
 The maximum size of each connection pool is set by the ``max_pool_size``
 option, which defaults to ``10``. If the number of in-use connections to
@@ -92,9 +92,9 @@ in your MongoDB topology for monitoring the server's state.
 For example, a client connected to a three-node replica set opens six
 monitoring sockets. If the application uses the default setting for
 ``max_pool_size`` and only queries the primary (default) node, then
-there can be at most ``16`` total connections in the connection pool. If the
+there can be at most 16 total connections in the connection pool. If the
 application uses a read preference to query the secondary nodes, those
-connection pools grow and there can be ``36`` total connections.
+connection pools grow and there can be 36 total connections.
 
 To support high numbers of concurrent MongoDB requests
 within one process, you can increase the value of the ``max_pool_size``

--- a/source/fundamentals/performance.txt
+++ b/source/fundamentals/performance.txt
@@ -111,7 +111,7 @@ option. The following code demonstrates how to specify a value for
 Connection pools are rate-limited. The ``max_connecting`` option
 determines the number of connections that the pool can create in
 parallel at any time. For example, if the value of ``max_connecting`` is
-``2``, as is by default, the third request that attempts to concurrently
+``2``, the default value, the third request that attempts to concurrently
 check out a connection succeeds only when one of the following cases occurs:
 
 - The connection pool finishes creating a connection and the number of

--- a/source/fundamentals/performance.txt
+++ b/source/fundamentals/performance.txt
@@ -84,7 +84,7 @@ and optimize performance.
 The maximum size of each connection pool is set by the ``max_pool_size``
 option, which defaults to ``10``. If the number of in-use connections to
 a server reaches the value of ``max_pool_size``, the next request to
-that server will wait until a connection becomes available.
+that server waits until a connection becomes available.
 
 In addition to the sockets needed to support your application's requests,
 each ``Client`` instance opens two more sockets per server
@@ -98,8 +98,8 @@ connection pools grow and there can be 36 total connections.
 
 To support high numbers of concurrent MongoDB requests
 within one process, you can increase the value of the ``max_pool_size``
-option. The following code demonstrates how to instantiate a ``Client``
-while specifying a value for ``max_pool_size``:
+option. The following code demonstrates how to specify a value for
+``max_pool_size`` when instantiating a ``Client``:
 
 .. code-block:: rust
    
@@ -114,23 +114,24 @@ parallel at any time. For example, if the value of ``max_connecting`` is
 ``2``, as is by default, the third request that attempts to concurrently
 check out a connection succeeds only when one of the following cases occurs:
 
-- The connection pool finishes creating a connection and there are fewer
-  than ``max_pool_size`` connections in the pool.
+- The connection pool finishes creating a connection and the number of
+  connections in the pool is less than the value of ``max_pool_size``.
 - An existing connection is checked back into the pool.
 - The driver's ability to reuse existing connections improves due to
-  rate-limits on connection creation.
+  rate limits on connection creation.
 
 You can set the minimum number of concurrent connections to
 each server with the ``min_pool_size`` option, which defaults to ``0``.
 The driver initializes the connection pool with this number of sockets. If
 sockets are closed and the total number of sockets, both in use and
-idle, to drop below the minimum, the connection pool opens more sockets until the
+idle, drops below the minimum, the connection pool opens more sockets until the
 minimum is reached.
 
 You can set the maximum amount of time that a connection can
 remain idle in the pool by setting the ``max_idle_time`` option.
-Once a connection has been idle for ``max_idle_time``, the connection
-pool removes and replaces it. This option defaults to ``0``, or no limit.
+Once a connection has been idle for the duration specified in
+``max_idle_time``, the connection pool removes and replaces that
+connection. This option defaults to ``0``, or no limit.
 
 When the ``Client::shutdown()`` method is called at any point in your
 application, the driver closes all idle sockets and closes all sockets


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-rust/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-31470>
Staging - https://preview-mongodbrustagir.gatsbyjs.io/rust/DOCSP-31470-conn-pool-perf/fundamentals/performance/#connection-pool

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
