### PR TITLE
[Rust] use structs to model data instead of Document in CRUD fundamentals

### DIFF
--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -4,6 +4,13 @@
 Access Data by Using a Cursor
 =============================
 
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta::
+   :keywords: loop, retrieve, process, batch
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -60,7 +60,7 @@ This guide includes the following sections:
 Sample Data for Examples
 ------------------------
 
-The examples in this guide uses the following data stored in a struct:
+The examples in this guide use the following data stored in a struct:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/crud/cursor.rs
    :language: rust

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -53,16 +53,22 @@ This guide includes the following sections:
 Sample Data for Examples
 ------------------------
 
-The examples in this guide use the following sample documents. Each
-document describes a fruit:
+The examples in this guide uses the following data stored in a struct:
 
-.. code-block:: json
-   :copyable: false
-   
-   { "name": "strawberry", "color": "red" },
-   { "name": "banana", "color": "yellow" },
-   { "name": "pomegranate", "color": "red" },
-   { "name": "pineapple", "color": "yellow" }
+.. code-block:: rust
+
+  #[derive(Serialize, Deserialize)]
+   struct Fruit {
+      name: String,
+      color: String
+   }
+
+   let strawberry = { "name": "strawberry", "color": "red" }
+   let banana = { "name": "banana", "color": "yellow" }
+   let pomegranate = { "name": "pomegranate", "color": "red" }
+   let pineapple = { "name": "pineapple", "color": "yellow" }
+
+  The data stored in the collection is the following:
 
 .. _rust-cursor-individual:
 

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -55,7 +55,7 @@ Sample Data for Examples
 
 The examples in this guide uses the following data stored in a struct:
 
-.. literalinclude:: /source/includes/fundamentals/code-snippets/crud/cursor.rs
+.. literalinclude:: /includes/fundamentals/code-snippets/crud/cursor.rs
    :language: rust
    :dedent:
    :start-after: start-sample-data

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -55,20 +55,11 @@ Sample Data for Examples
 
 The examples in this guide uses the following data stored in a struct:
 
-.. code-block:: rust
-
-  #[derive(Serialize, Deserialize)]
-   struct Fruit {
-      name: String,
-      color: String
-   }
-
-   let strawberry = { "name": "strawberry", "color": "red" }
-   let banana = { "name": "banana", "color": "yellow" }
-   let pomegranate = { "name": "pomegranate", "color": "red" }
-   let pineapple = { "name": "pineapple", "color": "yellow" }
-
-  The data stored in the collection is the following:
+.. literalinclude:: /source/includes/fundamentals/code-snippets/crud/cursor.rs
+   :language: rust
+   :dedent:
+   :start-after: start-sample-data
+   :end-before: end-sample-data
 
 .. _rust-cursor-individual:
 
@@ -136,8 +127,8 @@ collection:
       :language: console
       :visible: false
 
-      Document({"_id": ObjectId("..."), "name": String("strawberry"), "color": String("red")})
-      Document({"_id": ObjectId("..."), "name": String("pomegranate"), "color": String("red")})
+      Fruit { name: "strawberry", color: "red" }
+      Fruit { name: "pomegranate", color: "red" }
 
 .. _rust-cursor-indiv-stream:
 
@@ -184,12 +175,12 @@ collection:
       :visible: false
 
       Output from next() iteration:
-      { "_id": ObjectId("..."), "name": "strawberry", "color": "red" }
-      { "_id": ObjectId("..."), "name": "pomegranate", "color": "red" }
-      
+      Fruit { name: "strawberry", color: "red" }
+      Fruit { name: "pomegranate", color: "red" }
+
       Output from try_next() iteration:
-      { "_id": ObjectId("..."), "name": "banana", "color": "yellow" }
-      { "_id": ObjectId("..."), "name": "pineapple", "color": "yellow" }
+      Fruit { name: "banana", color: "yellow" }
+      Fruit { name: "pineapple", color: "yellow" }
 
 .. _rust-cursor-array:
 
@@ -226,10 +217,10 @@ You can use the following methods to retrieve documents as an array:
       :visible: false
 
       Output from collect():
-      [Ok(Document({"_id": ObjectId("..."), "name": String("strawberry"), "color": String("red")})), Ok(Document({"_id": ObjectId("..."), "name": String("pomegranate"), "color": String("red")}))]
-      
+      [Ok(Fruit { name: "strawberry", color: "red" }), Ok(Fruit { name: "pomegranate", color: "red" })]
+
       Output from try_collect():
-      [Document({"_id": ObjectId("..."), "name": String("banana"), "color": String("yellow")}), Document({"_id": ObjectId("..."), "name": String("pineapple"), "color": String("yellow")})]
+      [Fruit { name: "banana", color: "yellow" }, Fruit { name: "pineapple", color: "yellow" }]
 
 .. warning:: Avoid Exceeding Application Memory Limits
 

--- a/source/fundamentals/crud/read-operations/query.txt
+++ b/source/fundamentals/crud/read-operations/query.txt
@@ -285,6 +285,7 @@ field:
    uses the ``#[serde(skip_serializing_if = "Option::is_none")]`` attribute on two of its
    fields. This attribute specifies that the field be ignored if its value is ``None``. This
    prevents a ``description`` value of ``None`` from being returned on an ``$exists`` query.
+   
    See the `serialize_with <https://serde.rs/field-attrs.html#serialize_with>`__ Serde
    attribute for more information.
 

--- a/source/fundamentals/crud/read-operations/query.txt
+++ b/source/fundamentals/crud/read-operations/query.txt
@@ -102,8 +102,8 @@ that describe the fruit or its vendors.
    :start-after: begin-data-struct
    :end-before: end-data-struct
 
-The examples in the following sections query a collection of documents described by Fruit
-structs:
+The examples in the following sections query a collection of documents described by
+``Fruit`` structs:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/crud/query.rs
    :language: rust
@@ -281,12 +281,12 @@ field:
       vendors: None }
       
 .. note::
-   The :ref:`struct describing the documents<rust-query-sample-data>` uses ``#[serde(skip_serializing_if =
-   "Option::is_none")]`` field attributes to specify that the data be ignored if it is
-   specified as ``None``. This prevents a description field of ``None`` from being returned on am ``$exists`` query.
-   See the `serialize_with
-   <https://serde.rs/field-attrs.html#serialize_with>`__ Serde attribute for more
-   information.
+   The :ref:`Fruit struct describing the documents<rust-query-sample-data>` in this guide
+   uses the ``#[serde(skip_serializing_if = "Option::is_none")]`` attribute on two of its
+   fields. This attribute specifies that the field be ignored if its value is ``None``. This
+   prevents a ``description`` value of ``None`` from being returned on an ``$exists`` query.
+   See the `serialize_with <https://serde.rs/field-attrs.html#serialize_with>`__ Serde
+   attribute for more information.
 
 For a full list of element operators, see :manual:`Element
 Query Operators </reference/operator/query-element/>` in the Server manual.

--- a/source/fundamentals/crud/read-operations/query.txt
+++ b/source/fundamentals/crud/read-operations/query.txt
@@ -269,15 +269,7 @@ field:
       :language: json
       :visible: false
 
-      Document({"_id": Int32(2), "name": String("apple"), "quantity":
-      Int32(4), "description": String("Granny Smith")})
-      ********************* DO NOT MERGE
-      I need to figure out how to get MongoDB to ignore "None" entries in Structs
-      Current results:
-      Fruit { _id: "1", name: "orange", quantity: 7, description: None, vendors: None }
       Fruit { _id: "2", name: "apple", quantity: 4, description: Some("Granny Smith"), vendors: None }
-      Fruit { _id: "3", name: "banana", quantity: 36, description: None, vendors: None }
-      Fruit { _id: "4", name: "pear", quantity: 28, description: None, vendors: Some(["A", "C"]) }
 
 For a full list of element operators, see :manual:`Element
 Query Operators </reference/operator/query-element/>` in the Server manual.

--- a/source/fundamentals/crud/read-operations/query.txt
+++ b/source/fundamentals/crud/read-operations/query.txt
@@ -283,7 +283,7 @@ field:
 .. note::
    The :ref:`struct describing the documents<rust-query-sample-data>` uses ``#[serde(skip_serializing_if =
    "Option::is_none")]`` field attributes to specify that the data be ignored if it is
-   specified as ``None``. This prevents a description field of `None` from being returned on am ``$exists`` query.
+   specified as ``None``. This prevents a description field of ``None`` from being returned on am ``$exists`` query.
    See the `serialize_with
    <https://serde.rs/field-attrs.html#serialize_with>`__ Serde attribute for more
    information.

--- a/source/fundamentals/crud/read-operations/query.txt
+++ b/source/fundamentals/crud/read-operations/query.txt
@@ -97,13 +97,11 @@ information about its quantity. Some documents contain additional fields
 that describe the fruit or its vendors:
 
 
-.. code-block:: json
-   :copyable: true
-
-   { "_id": 1, "name": "orange", "quantity": 7 },
-   { "_id": 2, "name": "apple", "quantity": 4, "description": "Granny Smith" },
-   { "_id": 3, "name": "banana", "quantity": 36 },
-   { "_id": 4, "name": "pear", "quantity": 28, "vendors": ["A", "C" ] }
+.. literalinclude:: /includes/fundamentals/code-snippets/crud/query.rs
+   :language: rust
+   :dedent:
+   :start-after: begin-sample-docs
+   :end-before: end-sample-docs
 
 .. _rust-literal-values:
 
@@ -128,8 +126,7 @@ that has the value of ``"pear"``:
       :language: json
       :visible: false
 
-      Document({"_id": Int32(4), "name": String("pear"), "quantity":
-      Int32(28), "vendors": Array([String("A"), String("C")])})
+      Fruit { _id: "4", name: "pear", quantity: 28, description: None, vendors: Some(["A", "C"]) }
 
 .. note::
 
@@ -178,12 +175,9 @@ documents with a ``quantity`` value greater than ``5``:
       :language: json
       :visible: false
 
-      Document({"_id": Int32(1), "name": String("orange"), "quantity":
-      Int32(7)})
-      Document({"_id": Int32(3), "name": String("banana"), "quantity":
-      Int32(36)})
-      Document({"_id": Int32(4), "name": String("pear"), "quantity":
-      Int32(28), "vendors": Array([String("A"), String("C")])})
+      Fruit { _id: "1", name: "orange", quantity: 7, description: None, vendors: None }
+      Fruit { _id: "3", name: "banana", quantity: 36, description: None, vendors: None }
+      Fruit { _id: "4", name: "pear", quantity: 28, description: None, vendors: Some(["A", "C"]) }
 
 For more information on comparison operators, see :manual:`Comparison
 Query Operators </reference/operator/query-comparison/>` in the Server manual.
@@ -219,8 +213,7 @@ divisible by ``3``:
       :language: json
       :visible: false
 
-      Document({"_id": Int32(3), "name": String("banana"), "quantity":
-      Int32(36)})
+      Fruit { _id: "3", name: "banana", quantity: 36, description: None, vendors: None }
 
 .. note::
 
@@ -278,6 +271,13 @@ field:
 
       Document({"_id": Int32(2), "name": String("apple"), "quantity":
       Int32(4), "description": String("Granny Smith")})
+      ********************* DO NOT MERGE
+      I need to figure out how to get MongoDB to ignore "None" entries in Structs
+      Current results:
+      Fruit { _id: "1", name: "orange", quantity: 7, description: None, vendors: None }
+      Fruit { _id: "2", name: "apple", quantity: 4, description: Some("Granny Smith"), vendors: None }
+      Fruit { _id: "3", name: "banana", quantity: 36, description: None, vendors: None }
+      Fruit { _id: "4", name: "pear", quantity: 28, description: None, vendors: Some(["A", "C"]) }
 
 For a full list of element operators, see :manual:`Element
 Query Operators </reference/operator/query-element/>` in the Server manual.
@@ -312,8 +312,7 @@ for documents with a ``quantity`` value that is divisible by 3:
       :language: json
       :visible: false
 
-      Document({"_id": Int32(3), "name": String("banana"), "quantity":
-      Int32(36)})
+      Fruit { _id: "3", name: "banana", quantity: 36, description: None, vendors: None }
 
 For a full list of evaluation operators, see :manual:`Evaluation
 Query Operators </reference/operator/query-evaluation/>` in the Server manual.
@@ -347,8 +346,7 @@ bits set as ``7``, which is equivalent to  ``00000111`` in binary:
       :language: json
       :visible: false
 
-      Document({"_id": Int32(1), "name": String("orange"), "quantity":
-      Int32(7)})
+      Fruit { _id: "1", name: "orange", quantity: 7, description: None, vendors: None }
 
 For a full list of bitwise operators, see :manual:`Bitwise
 Query Operators </reference/operator/query-bitwise/>` in the Server manual.
@@ -381,8 +379,7 @@ contains ``"C"``:
       :language: json
       :visible: false
 
-      Document({"_id": Int32(4), "name": String("pear"), "quantity":
-      Int32(28), "vendors": Array([String("A"), String("C")])})
+      Fruit { _id: "4", name: "pear", quantity: 28, description: None, vendors: Some(["A", "C"]) }
 
 For a full list of bitwise operators, see :manual:`Array
 Query Operators </reference/operator/query-array/>` in the Server manual.

--- a/source/fundamentals/crud/read-operations/query.txt
+++ b/source/fundamentals/crud/read-operations/query.txt
@@ -94,8 +94,22 @@ Sample Data
 The examples in this guide use the following sample documents. Each
 document represents a fruit in a store's inventory and contains
 information about its quantity. Some documents contain additional fields
-that describe the fruit or its vendors:
+that describe the fruit or its vendors.
 
+Note that the struct describing the data uses ``#[serde(skip_serializing_if =
+"Option::is_none")]`` commands to indicate that the data should be ignored if it is
+specified as ``None``. See the `serialize_with
+<https://serde.rs/field-attrs.html#serialize_with>`__ Serde attribute for more
+information.
+
+.. literalinclude:: /includes/fundamentals/code-snippets/crud/query.rs
+   :language: rust
+   :dedent:
+   :start-after: begin-data-struct
+   :end-before: end-data-struct
+
+The examples in the following sections query a collection of documents described by Fruit
+structs:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/crud/query.rs
    :language: rust

--- a/source/fundamentals/crud/read-operations/query.txt
+++ b/source/fundamentals/crud/read-operations/query.txt
@@ -96,12 +96,6 @@ document represents a fruit in a store's inventory and contains
 information about its quantity. Some documents contain additional fields
 that describe the fruit or its vendors.
 
-Note that the struct describing the data uses ``#[serde(skip_serializing_if =
-"Option::is_none")]`` commands to indicate that the data should be ignored if it is
-specified as ``None``. See the `serialize_with
-<https://serde.rs/field-attrs.html#serialize_with>`__ Serde attribute for more
-information.
-
 .. literalinclude:: /includes/fundamentals/code-snippets/crud/query.rs
    :language: rust
    :dedent:
@@ -283,7 +277,16 @@ field:
       :language: json
       :visible: false
 
-      Fruit { _id: "2", name: "apple", quantity: 4, description: Some("Granny Smith"), vendors: None }
+      Fruit { _id: "2", name: "apple", quantity: 4, description: Some("Granny Smith"),
+      vendors: None }
+      
+.. note::
+   The :ref:`struct describing the documents<rust-query-sample-data>` uses ``#[serde(skip_serializing_if =
+   "Option::is_none")]`` field attributes to specify that the data be ignored if it is
+   specified as ``None``. This prevents a description field of `None` from being returned on am ``$exists`` query.
+   See the `serialize_with
+   <https://serde.rs/field-attrs.html#serialize_with>`__ Serde attribute for more
+   information.
 
 For a full list of element operators, see :manual:`Element
 Query Operators </reference/operator/query-element/>` in the Server manual.

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -53,13 +53,11 @@ The examples in this guide use the following sample documents. Each
 document represents an item in a store's inventory and contains
 information about its categorization and unit price:
 
-.. code-block:: json
-   :copyable: false
-   
-   { "item": "candle", "category": "decor", "unit_price": 2.89 },
-   { "item": "blender", "category": "kitchen", "unit_price": 38.49 },
-   { "item": "placemat", "category": "kitchen", "unit_price": 3.19 },
-   { "item": "watering can", "category": "garden", "unit_price": 11.99 }
+.. literalinclude:: /includes/fundamentals/code-snippets/crud/retrieve.rs
+   :language: rust
+   :dedent:
+   :start-after: start-sample
+   :end-before: end-sample
 
 .. _rust-retrieve-find:
 

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -223,8 +223,8 @@ following parameters:
       :language: console
       :visible: false
 
-      { "_id": { ... }, "item": "watering can", "category": "garden", "unit_price": 11.99 }
-      { "_id": { ... }, "item": "candle", "category": "decor", "unit_price": 2.89 }
+      Inventory { item: "watering can", category: "garden", unit_price: 11.99 }
+      Inventory { item: "candle", category: "decor", unit_price: 2.89 }
 
 .. _rust-find-one-example:
 
@@ -252,20 +252,11 @@ following parameters:
       :visible: false
 
       Some(
-        Document({
-            "_id": ObjectId(
-                "...",
-            ),
-            "item": String(
-                "watering can",
-            ),
-            "category": String(
-                "garden",
-            ),
-            "unit_price": Double(
-                11.99,
-            ),
-        }),
+          Inventory {
+              item: "watering can",
+              category: "garden",
+              unit_price: 11.99,
+          },
       )
 
 .. _rust-retrieve-aggregation:
@@ -388,9 +379,9 @@ pipeline that contains the following stages:
       :language: console
       :visible: false
 
-      { "_id": { "category": "garden" }, "avg_price": 11.99 }
-      { "_id": { "category": "decor" }, "avg_price": 2.89 }
-      { "_id": { "category": "kitchen" }, "avg_price": 20.84 }
+      Document({"_id": Document({"category": String("decor")}), "avg_price": Double(2.890000104904175)})
+      Document({"_id": Document({"category": String("kitchen")}), "avg_price": Double(20.840000867843628)})
+      Document({"_id": Document({"category": String("garden")}), "avg_price": Double(11.989999771118164)})
 
 .. _rust-crud-retrieve-addtl-info:
 

--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -105,7 +105,7 @@ document into the ``books`` collection:
       :language: console
       :visible: false
 
-      Inserted document with _id: ObjectId("...")
+      Inserted document with _id: 8
 
 .. include:: /includes/fundamentals/automatic-creation.rst
 
@@ -202,9 +202,9 @@ multiple documents into the ``books`` collection:
       :visible: false
 
       Inserted documents with _ids:
-      ObjectId("...")
-      ObjectId("...")
-      ObjectId("...")
+      Int32(5)
+      Int32(6)
+      Int32(7)
 
 .. include:: /includes/fundamentals/automatic-creation.rst
 

--- a/source/includes/fundamentals/code-snippets/crud/cursor.rs
+++ b/source/includes/fundamentals/code-snippets/crud/cursor.rs
@@ -18,7 +18,7 @@ async fn main() -> mongodb::error::Result<()> {
 
     let my_coll: Collection<Fruit> = client.database("db").collection("fruits");
 
-    // start-sample-data
+    //start-sample-data
     let docs = vec! [
         Fruit { 
             name: "strawberry".to_string(), 

--- a/source/includes/fundamentals/code-snippets/crud/cursor.rs
+++ b/source/includes/fundamentals/code-snippets/crud/cursor.rs
@@ -1,18 +1,51 @@
-use bson::Document;
 use futures::{ StreamExt, TryStreamExt };
-use mongodb::{ bson::doc, Client, error::Result, options::{ FindOptions, CursorType } };
+use mongodb::{ bson::doc, bson::Document, Client, Collection, error::Result, options::{ FindOptions, CursorType } };
+
+use serde::{ Deserialize, Serialize };
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Fruit {
+    name: String,
+    color: String
+}
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> mongodb::error::Result<()> {
+    // Replace the placeholder with your Atlas connection string
     let uri = "<connection string>";
+
     let client = Client::with_uri_str(uri).await?;
 
-    let my_coll = client.database("db").collection::<Document>("fruits");
+    let my_coll: Collection<Fruit> = client.database("db").collection("fruits");
+
+    // start-sample-data
+    let docs = vec! [
+        Fruit { 
+            name: "strawberry".to_string(), 
+            color: "red".to_string() 
+        },
+        Fruit { 
+            name: "banana".to_string(), 
+            color: "yellow".to_string() 
+        },
+        Fruit { 
+            name: "pomegranate".to_string(), 
+            color: "red".to_string() 
+        },
+        Fruit { 
+            name: "pineapple".to_string(), 
+            color: "yellow".to_string() 
+        }
+    ];
+    //end-sample-data
+
+    // Inserts sample documents into the collection
+    let insert_many_result = my_coll.insert_many(docs, None).await?;
 
     // start-indiv-builtin
     let mut cursor = my_coll.find(doc! { "color": "red" }, None).await?;
     while cursor.advance().await? {
-        println!("{}", cursor.deserialize_current()?);
+        println!("{:?}", cursor.deserialize_current()?);
     }
     // end-indiv-builtin
 
@@ -22,14 +55,14 @@ async fn main() -> Result<()> {
     let mut cursor = my_coll.find(doc! { "color": "red" }, None).await?;
     println!("Output from next() iteration:");
     while let Some(doc) = cursor.next().await {
-        println!("{}", doc?);
+        println!("{:?}", doc?);
     }
 
     println!();
     let mut cursor = my_coll.find(doc! { "color": "yellow" }, None).await?;
     println!("Output from try_next() iteration:");
     while let Some(doc) = cursor.try_next().await? {
-        println!("{}", doc);
+        println!("{:?}", doc);
     }
     // end-indiv-stream
 
@@ -38,13 +71,13 @@ async fn main() -> Result<()> {
     // start-array
     let cursor = my_coll.find(doc! { "color": "red" }, None).await?;
     println!("Output from collect():");
-    let v: Vec<Result<Document>> = cursor.collect().await;
+    let v: Vec<Result<Fruit>> = cursor.collect().await;
     println!("{:?}", v);
 
     println!();
     let cursor = my_coll.find(doc! { "color": "yellow" }, None).await?;
     println!("Output from try_collect():");
-    let v: Vec<Document> = cursor.try_collect().await?;
+    let v: Vec<Fruit> = cursor.try_collect().await?;
     println!("{:?}", v);
     // end-array
 

--- a/source/includes/fundamentals/code-snippets/crud/insert.rs
+++ b/source/includes/fundamentals/code-snippets/crud/insert.rs
@@ -30,10 +30,25 @@ async fn main() -> mongodb::error::Result<()> {
 
     // begin-insert-many
     let my_coll: Collection<Document> = client.database("db").collection("books");
+
+    type Books struct {
+        title string
+        author string
+    };
+    
     let docs = vec![
-        doc! { "title": "Cat's Cradle", "author": "Kurt Vonnegut Jr." },
-        doc! { "title": "In Memory of Memory", "author": "Maria Stepanova" },
-        doc! { "title": "Pride and Prejudice", "author": "Jane Austen" }
+        Books {
+            title: "Cat's Cradle",
+            author: "Kurt Vonnegut Jr."
+        },
+        Books {
+            title: "In Memory of Memory",
+            author: "Maria Stepanova"
+        },
+        Books {
+            title: "Pride and Prejudice",
+            author: "Jane Austen"
+        }
     ];
 
     let insert_many_result = my_coll.insert_many(docs, None).await?;

--- a/source/includes/fundamentals/code-snippets/crud/insert.rs
+++ b/source/includes/fundamentals/code-snippets/crud/insert.rs
@@ -1,12 +1,21 @@
-use std::env;
-use bson::{ Document, bson };
+use futures::TryStreamExt;
 use mongodb::{
     bson::doc,
-    Client,
-    Collection,
+    Client, 
+    Collection, 
     results::{ InsertOneResult, InsertManyResult },
-    options::{ InsertOneOptions, InsertManyOptions },
+    options::{ InsertOneOptions, InsertManyOptions }, 
 };
+use std::env;
+
+use serde::{ Deserialize, Serialize };
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Book {
+    _id: i32,
+    title: String,
+    author: String
+}
 
 #[tokio::main]
 async fn main() -> mongodb::error::Result<()> {
@@ -15,8 +24,8 @@ async fn main() -> mongodb::error::Result<()> {
     let client = Client::with_uri_str(uri).await?;
 
     // begin-insert-one
-    let my_coll: Collection<Document> = client.database("db").collection("books");
-    let doc = doc! { "title": "Atonement", "author": "Ian McEwan" };
+    let my_coll: Collection<Book> = client.database("db").collection("books");
+    let doc = Book { _id: 8, title: "Atonement".to_string(), author: "Ian McEwan".to_string() };
 
     let insert_one_result = my_coll.insert_one(doc, None).await?;
     println!("Inserted document with _id: {}", insert_one_result.inserted_id);
@@ -29,47 +38,43 @@ async fn main() -> mongodb::error::Result<()> {
     // end-one-options
 
     // begin-insert-many
-    let my_coll: Collection<Document> = client.database("db").collection("books");
-
-    type Books struct {
-        title string
-        author string
-    };
-    
     let docs = vec![
-        Books {
-            title: "Cat's Cradle",
-            author: "Kurt Vonnegut Jr."
+        Book {
+            _id: 5,
+            title: "Cat's Cradle".to_string(),
+            author: "Kurt Vonnegut Jr.".to_string()
         },
-        Books {
-            title: "In Memory of Memory",
-            author: "Maria Stepanova"
+        Book {
+            _id: 6,
+            title: "In Memory of Memory".to_string(),
+            author: "Maria Stepanova".to_string()
         },
-        Books {
-            title: "Pride and Prejudice",
-            author: "Jane Austen"
+        Book {
+            _id: 7,
+            title: "Pride and Prejudice".to_string(),
+            author: "Jane Austen".to_string()
         }
     ];
 
     let insert_many_result = my_coll.insert_many(docs, None).await?;
     println!("Inserted documents with _ids:");
     for (_key, value) in &insert_many_result.inserted_ids {
-        println!("{}", value);
+        println!("{:?}", value);
     }
     // end-insert-many
 
     // begin-many-options
     let _opts = InsertManyOptions::builder()
-        .comment(bson!("hello world"))
+        .comment(Some("hello world".into()))
         .build();
     // end-many-options
 
     // begin-unordered
     let docs = vec![
-        doc! { "_id": 1, "title": "Where the Wild Things Are" },
-        doc! { "_id": 2, "title": "The Very Hungry Caterpillar" },
-        doc! { "_id": 1, "title": "Blueberries for Sal" },
-        doc! { "_id": 3, "title": "Goodnight Moon" }
+        Book { _id: 1, title: "Where the Wild Things Are".to_string(), author: "".to_string() },
+        Book { _id: 2, title: "The Very Hungry Caterpillar".to_string(), author: "".to_string() },
+        Book { _id: 4, title: "Blueberries for Sal".to_string(), author: "".to_string() },
+        Book { _id: 3, title: "Goodnight Moon".to_string(), author: "".to_string() }
     ];
 
     let opts = InsertManyOptions::builder().ordered(false).build();

--- a/source/includes/fundamentals/code-snippets/crud/query.rs
+++ b/source/includes/fundamentals/code-snippets/crud/query.rs
@@ -4,6 +4,7 @@ use mongodb::{ bson::{doc, Document}, Client, Collection };
 
 use serde::{ Deserialize, Serialize };
 
+// begin-data-struct
 #[derive(Serialize, Deserialize, Debug)]
 struct Fruit {
     _id: String,
@@ -14,6 +15,7 @@ struct Fruit {
     #[serde(skip_serializing_if = "Option::is_none")]
     vendors: Option<Vec<String>>
 }
+// end-data-struct
 
 #[tokio::main]
 async fn main() -> mongodb::error::Result<()> {

--- a/source/includes/fundamentals/code-snippets/crud/query.rs
+++ b/source/includes/fundamentals/code-snippets/crud/query.rs
@@ -9,16 +9,42 @@ async fn main() -> mongodb::error::Result<()> {
     let client = Client::with_uri_str(uri).await?;
     let my_coll: Collection<Document> = client.database("db").collection("fruits");
 
-    let docs = vec![
-        //begin-sample-docs
-        doc! { "_id": 1, "name": "orange", "quantity": 7 },
-        doc! { "_id": 2, "name": "apple", "quantity": 4, "description": "Granny Smith" },
-        doc! { "_id": 3, "name": "banana", "quantity": 36 },
-        doc! { "_id": 4, "name": "pear", "quantity": 28, "vendors": ["A", "C" ] }
-        //end-sample-docs
+    type Fruits struct {
+        name  string
+        quantity number
+        description string
+        vendors [string]
+    };
+
+    //begin-sample-docs
+    let docs = vec! [
+        Fruit { 
+            _id: 1, 
+            name: "orange", 
+            quantity: 7 
+        },
+        Fruit { 
+            _id: 2, 
+            name: "apple", 
+            quantity: 4,
+            description: "Granny Smith" 
+        },
+        Fruit { 
+            _id: 3, 
+            name: "banana", 
+            quantity: 36 
+        },
+        Fruit { 
+            _id: 4, 
+            name: "pear", 
+            quantity: 28,
+            vendors: ["A", "C" ]
+        },
     ];
+    //end-sample-docs
+
     // Inserts sample documents into the collection
-    my_coll.insert_many(docs, None).await?;
+    let insert_many_result = my_coll.insert_many(docs, None).await?;
 
     //begin-literal
     let query = doc! { "name": "pear" };

--- a/source/includes/fundamentals/code-snippets/crud/query.rs
+++ b/source/includes/fundamentals/code-snippets/crud/query.rs
@@ -3,42 +3,61 @@ use bson::Document;
 use futures::TryStreamExt;
 use mongodb::{ bson::doc, Client, Collection };
 
+use serde::{ Deserialize, Serialize };
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Fruit {
+    _id: String,
+    name: String,
+    quantity: i32,
+    description: Option<String>,
+    vendors: Option<Vec<String>>
+}
+
 #[tokio::main]
 async fn main() -> mongodb::error::Result<()> {
     let uri = "<connection string>";
     let client = Client::with_uri_str(uri).await?;
-    let my_coll: Collection<Document> = client.database("db").collection("fruits");
+    let my_coll: Collection<Fruit> = client.database("db").collection("fruits");
 
-    type Fruits struct {
-        name  string
-        quantity number
-        description string
-        vendors [string]
-    };
+    #[derive(Debug)]
+    struct Fruit {
+        _id: String,
+        name: String,
+        quantity: i32,
+        description: Option<String>,
+        vendors: Option<Vec<String>>
+    }
 
     //begin-sample-docs
     let docs = vec! [
         Fruit { 
-            _id: 1, 
-            name: "orange", 
-            quantity: 7 
+            _id: 1.to_string(), 
+            name: "orange".to_string(), 
+            quantity: 7,
+            description: None,
+            vendors: None
         },
         Fruit { 
-            _id: 2, 
-            name: "apple", 
+            _id: 2.to_string(), 
+            name: "apple".to_string(), 
             quantity: 4,
-            description: "Granny Smith" 
+            description: Some("Granny Smith".to_string()),
+            vendors: None
         },
         Fruit { 
-            _id: 3, 
-            name: "banana", 
-            quantity: 36 
+            _id: 3.to_string(), 
+            name: "banana".to_string(), 
+            quantity: 36,
+            description: None,
+            vendors: None
         },
         Fruit { 
-            _id: 4, 
-            name: "pear", 
+            _id: 4.to_string(), 
+            name: "pear".to_string(), 
             quantity: 28,
-            vendors: ["A", "C" ]
+            description: None,
+            vendors: vec!["A".to_string(), "C".to_string() ].into()
         },
     ];
     //end-sample-docs

--- a/source/includes/fundamentals/code-snippets/crud/query.rs
+++ b/source/includes/fundamentals/code-snippets/crud/query.rs
@@ -1,7 +1,6 @@
 use std::env;
-use bson::Document;
 use futures::TryStreamExt;
-use mongodb::{ bson::doc, Client, Collection };
+use mongodb::{ bson::{doc, Document}, Client, Collection };
 
 use serde::{ Deserialize, Serialize };
 
@@ -10,7 +9,9 @@ struct Fruit {
     _id: String,
     name: String,
     quantity: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     vendors: Option<Vec<String>>
 }
 
@@ -19,15 +20,6 @@ async fn main() -> mongodb::error::Result<()> {
     let uri = "<connection string>";
     let client = Client::with_uri_str(uri).await?;
     let my_coll: Collection<Fruit> = client.database("db").collection("fruits");
-
-    #[derive(Debug)]
-    struct Fruit {
-        _id: String,
-        name: String,
-        quantity: i32,
-        description: Option<String>,
-        vendors: Option<Vec<String>>
-    }
 
     //begin-sample-docs
     let docs = vec! [

--- a/source/includes/fundamentals/code-snippets/crud/retrieve.rs
+++ b/source/includes/fundamentals/code-snippets/crud/retrieve.rs
@@ -13,7 +13,7 @@ struct Inventory {
 
 #[tokio::main]
 async fn main() -> mongodb::error::Result<()> {
-    let uri = "<connection string>";
+    let uri = "mongodb+srv://admin:adminpassword@cluster0.ak0rruc.mongodb.net/?retryWrites=true&w=majority";
     let client = Client::with_uri_str(uri).await?;
     let my_coll: Collection<Inventory> = client.database("db").collection("inventory");
 

--- a/source/includes/fundamentals/code-snippets/crud/retrieve.rs
+++ b/source/includes/fundamentals/code-snippets/crud/retrieve.rs
@@ -13,7 +13,7 @@ struct Inventory {
 
 #[tokio::main]
 async fn main() -> mongodb::error::Result<()> {
-    let uri = "mongodb+srv://admin:adminpassword@cluster0.ak0rruc.mongodb.net/?retryWrites=true&w=majority";
+    let uri = "connection string";
     let client = Client::with_uri_str(uri).await?;
     let my_coll: Collection<Inventory> = client.database("db").collection("inventory");
 

--- a/source/includes/fundamentals/code-snippets/crud/retrieve.rs
+++ b/source/includes/fundamentals/code-snippets/crud/retrieve.rs
@@ -6,18 +6,15 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> mongodb::error::Result<()> {
-    let uri = "<connection string>";
+    let uri = "mongodb+srv://admin:adminpassword@cluster0.ak0rruc.mongodb.net/?retryWrites=true&w=majority";
     let client = Client::with_uri_str(uri).await?;
     let my_coll: Collection<Document> = client.database("db").collection("inventory");
 
-    // let docs = vec![
-    //     doc! { "item": "candle", "category": "decor", "unit_price": 2.89 },
-    //     doc! { "item": "blender", "category": "kitchen", "unit_price": 38.49 },
-    //     doc! { "item": "placemat", "category": "kitchen", "unit_price": 3.19 },
-    //     doc! { "item": "watering can", "category": "garden", "unit_price": 11.99 }
-    // ];
-
-    // my_coll.insert_many(docs, None).await?;
+    type Inventory struct {
+        item  string
+        category string
+        unit_price number
+    };
 
     // start-sample
     let docs = vec! [

--- a/source/includes/fundamentals/code-snippets/crud/retrieve.rs
+++ b/source/includes/fundamentals/code-snippets/crud/retrieve.rs
@@ -10,14 +10,41 @@ async fn main() -> mongodb::error::Result<()> {
     let client = Client::with_uri_str(uri).await?;
     let my_coll: Collection<Document> = client.database("db").collection("inventory");
 
-    let docs = vec![
-        doc! { "item": "candle", "category": "decor", "unit_price": 2.89 },
-        doc! { "item": "blender", "category": "kitchen", "unit_price": 38.49 },
-        doc! { "item": "placemat", "category": "kitchen", "unit_price": 3.19 },
-        doc! { "item": "watering can", "category": "garden", "unit_price": 11.99 }
-    ];
+    // let docs = vec![
+    //     doc! { "item": "candle", "category": "decor", "unit_price": 2.89 },
+    //     doc! { "item": "blender", "category": "kitchen", "unit_price": 38.49 },
+    //     doc! { "item": "placemat", "category": "kitchen", "unit_price": 3.19 },
+    //     doc! { "item": "watering can", "category": "garden", "unit_price": 11.99 }
+    // ];
 
-    my_coll.insert_many(docs, None).await?;
+    // my_coll.insert_many(docs, None).await?;
+
+    // start-sample
+    let docs = vec! [
+        Inventory {
+            item: "candle".to_string(),
+            category: "decor".to_string(),
+            unit_price: 2.89,
+        },
+        Inventory {
+            item: "blender".to_string(),
+            category: "kitchen".to_string(),
+            unit_price: 38.49,
+        },
+        Inventory {
+            item: "placemat".to_string(),
+            category: "kitchen".to_string(),
+            unit_price: 3.19,
+        },
+        Inventory {
+            item: "watering can".to_string(),
+            category: "garden".to_string(),
+            unit_price: 11.99,
+        }
+    ];
+    // end-sample
+
+    let insert_many_result = my_coll.insert_many(docs, None).await?;
 
     // begin-find-many
     let opts = FindOptions::builder()

--- a/source/includes/fundamentals/code-snippets/crud/retrieve.rs
+++ b/source/includes/fundamentals/code-snippets/crud/retrieve.rs
@@ -1,20 +1,21 @@
-use bson::Document;
-use chrono::{ TimeZone, Utc };
 use futures::TryStreamExt;
-use mongodb::{ bson::doc, Client, Collection, options::{ FindOptions, FindOneOptions } };
+use mongodb::{ bson::doc, bson::Document, Client, Collection, options::{ FindOptions, FindOneOptions } };
 use std::env;
+
+use serde::{ Deserialize, Serialize };
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Inventory {
+    item: String,
+    category: String,
+    unit_price: f32
+}
 
 #[tokio::main]
 async fn main() -> mongodb::error::Result<()> {
-    let uri = "mongodb+srv://admin:adminpassword@cluster0.ak0rruc.mongodb.net/?retryWrites=true&w=majority";
+    let uri = "<connection string>";
     let client = Client::with_uri_str(uri).await?;
-    let my_coll: Collection<Document> = client.database("db").collection("inventory");
-
-    type Inventory struct {
-        item  string
-        category string
-        unit_price number
-    };
+    let my_coll: Collection<Inventory> = client.database("db").collection("inventory");
 
     // start-sample
     let docs = vec! [
@@ -41,6 +42,7 @@ async fn main() -> mongodb::error::Result<()> {
     ];
     // end-sample
 
+    // Inserts sample documents into the collection
     let insert_many_result = my_coll.insert_many(docs, None).await?;
 
     // begin-find-many
@@ -58,7 +60,7 @@ async fn main() -> mongodb::error::Result<()> {
     ).await?;
 
     while let Some(result) = cursor.try_next().await? {
-        println!("{}", result);
+        println!("{:?}", result);
     };
     
     // end-find-many
@@ -85,7 +87,7 @@ async fn main() -> mongodb::error::Result<()> {
 
     let mut cursor = my_coll.aggregate(pipeline, None).await?;
     while let Some(result) = cursor.try_next().await? {
-        println!("{}", result);
+        println!("{:?}", result);
     };
     // end-agg
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-rust/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-33480>

Staging:
-  https://docs-mongodbcom-staging.corp.mongodb.com/rust/docsworker-xlarge/DOCSP-33480/fundamentals/crud/read-operations/retrieve/
- https://docs-mongodbcom-staging.corp.mongodb.com/rust/docsworker-xlarge/DOCSP-33480/fundamentals/crud/read-operations/query/
- https://docs-mongodbcom-staging.corp.mongodb.com/rust/docsworker-xlarge/DOCSP-33480/fundamentals/crud/read-operations/cursor/
- https://docs-mongodbcom-staging.corp.mongodb.com/rust/docsworker-xlarge/DOCSP-33480/fundamentals/crud/write-operations/insert/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
