### PR TITLE
DOCSP-35254: Connection pooling subsections

### DIFF
--- a/source/fundamentals/performance.txt
+++ b/source/fundamentals/performance.txt
@@ -142,6 +142,17 @@ sockets are closed and the total number of sockets, both in use and
 idle, drops below the minimum, the connection pool opens more sockets until the
 minimum is reached.
 
+The following code sets the ``max_connecting`` and ``min_pool_size`` options when
+instantiating a ``Client``:
+
+.. code-block:: rust
+   
+   let mut client_options = ClientOptions::parse("<connection string>").await?;
+   client_options.max_connecting = Some(3);
+   client_options.min_pool_size = Some(1);
+
+   let client = Client::with_options(client_options)?;
+
 Configure Maximum Idle Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -157,6 +168,16 @@ that are in use as they are returned to the pool. Calling ``Client::shutdown()``
 closes only inactive sockets, so you cannot interrupt or terminate
 any ongoing operations by using this method. The driver closes these
 sockets only when the process completes.
+
+The following code sets the value of the ``max_idle_time`` option to
+``90`` seconds when instantiating a ``Client``:
+
+.. code-block:: rust
+   
+   let mut client_options = ClientOptions::parse("<connection string>").await?;
+   client_options.max_idle_time = Some(Duration::new(90, 0));
+
+   let client = Client::with_options(client_options)?;
 
 .. _rust-performance-parallelism:
 

--- a/source/fundamentals/performance.txt
+++ b/source/fundamentals/performance.txt
@@ -122,7 +122,7 @@ option. The following code demonstrates how to specify a value for
 
 .. code-block:: rust
    
-   let mut client_options = ClientOptions::parse("<connection string>").await?;
+   let mut client_options = ClientOptions::parse_async("<connection string>").await?;
    client_options.max_pool_size = Some(20);
 
    let client = Client::with_options(client_options)?;
@@ -156,7 +156,7 @@ instantiating a ``Client``:
 
 .. code-block:: rust
    
-   let mut client_options = ClientOptions::parse("<connection string>").await?;
+   let mut client_options = ClientOptions::parse_async("<connection string>").await?;
    client_options.max_connecting = Some(3);
    client_options.min_pool_size = Some(1);
 
@@ -185,7 +185,7 @@ The following code sets the value of the ``max_idle_time`` option to
 
 .. code-block:: rust
    
-   let mut client_options = ClientOptions::parse("<connection string>").await?;
+   let mut client_options = ClientOptions::parse_async("<connection string>").await?;
    client_options.max_idle_time = Some(Duration::new(90, 0));
 
    let client = Client::with_options(client_options)?;

--- a/source/fundamentals/performance.txt
+++ b/source/fundamentals/performance.txt
@@ -82,13 +82,20 @@ settings:
    let client = Client::with_uri_str("<connection string>").await?;
 
 Alternatively, you can tune the connection pool to best fit the needs of your
-application and optimize performance.
+application and optimize performance. For more information on how to customize
+your connection settings, see the following subsections of this guide:
+
+- :ref:`rust-max-pool`
+- :ref:`rust-concurrent-connections`
+- :ref:`rust-max-idle`
 
 .. tip::
    
    To learn more about configuring a connection pool, see
    :manual:`Tuning Your Connection Pool Settings
    </tutorial/connection-pool-performance-tuning/>` in the Server manual.
+
+.. _rust-max-pool:
 
 Configure Maximum Pool Size
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -119,6 +126,8 @@ option. The following code demonstrates how to specify a value for
    client_options.max_pool_size = Some(20);
 
    let client = Client::with_options(client_options)?;
+
+.. _rust-concurrent-connections:
 
 Configure Concurrent Connection Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -152,6 +161,8 @@ instantiating a ``Client``:
    client_options.min_pool_size = Some(1);
 
    let client = Client::with_options(client_options)?;
+
+.. _rust-max-idle:
 
 Configure Maximum Idle Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/performance.txt
+++ b/source/fundamentals/performance.txt
@@ -71,15 +71,27 @@ Connection Pool
 
 Every ``Client`` instance has a built-in connection pool for each server
 in your MongoDB topology. Connection pools open sockets on demand to
-support concurrent requests to MongoDB in your application. You can
-tune the connection pool to best fit the needs of your application
-and optimize performance.
+support concurrent requests to MongoDB in your application. 
+
+The default configuration for a ``Client`` works for most applications.
+The following code shows how to create a client with default connection
+settings:
+
+.. code-block:: rust
+   
+   let client = Client::with_uri_str("<connection string>").await?;
+
+Alternatively, you can tune the connection pool to best fit the needs of your
+application and optimize performance.
 
 .. tip::
    
    To learn more about configuring a connection pool, see
    :manual:`Tuning Your Connection Pool Settings
    </tutorial/connection-pool-performance-tuning/>` in the Server manual.
+
+Configure Maximum Pool Size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The maximum size of each connection pool is set by the ``max_pool_size``
 option, which defaults to ``10``. If the number of in-use connections to
@@ -108,6 +120,9 @@ option. The following code demonstrates how to specify a value for
 
    let client = Client::with_options(client_options)?;
 
+Configure Concurrent Connection Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Connection pools are rate-limited. The ``max_connecting`` option
 determines the number of connections that the pool can create in
 parallel at any time. For example, if the value of ``max_connecting`` is
@@ -127,6 +142,9 @@ sockets are closed and the total number of sockets, both in use and
 idle, drops below the minimum, the connection pool opens more sockets until the
 minimum is reached.
 
+Configure Maximum Idle Time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 You can set the maximum amount of time that a connection can
 remain idle in the pool by setting the ``max_idle_time`` option.
 Once a connection has been idle for the duration specified in
@@ -139,14 +157,6 @@ that are in use as they are returned to the pool. Calling ``Client::shutdown()``
 closes only inactive sockets, so you cannot interrupt or terminate
 any ongoing operations by using this method. The driver closes these
 sockets only when the process completes.
-
-The default configuration for a ``Client`` works for most applications.
-The following code shows how to create a client with default connection
-settings:
-
-.. code-block:: rust
-   
-   let client = Client::with_uri_str("<connection string>").await?;
 
 .. _rust-performance-parallelism:
 

--- a/source/fundamentals/serialization.txt
+++ b/source/fundamentals/serialization.txt
@@ -66,8 +66,8 @@ Custom Data Model
 You can use any Rust data type that implements the ``Serialize`` and
 ``Deserialize`` traits from the ``serde`` crate as the generic type
 parameter for a ``Collection`` instance. To implement the ``Serialize``
-and ``Deserialize`` traits, you must use the following ``derive``
-statement before defining a Rust type:
+and ``Deserialize`` traits, you must include the following ``derive``
+attribute before defining a Rust type:
 
 .. code-block:: rust
    


### PR DESCRIPTION
# Pull Request Info
 I also included a small terminology fix in this PR (derive statement -> derive attribute)

[PR Reviewing Guidelines](https://github.com/mongodb/docs-rust/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-35254>
Staging - <https://preview-mongodbnorareidy.gatsbyjs.io/rust/DOCSP-35254-pool-subsections/fundamentals/performance/#std-label-rust-performance-pool>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
