### PR TITLE
fix meta keywords typo

### DIFF
--- a/source/connection-troubleshooting.txt
+++ b/source/connection-troubleshooting.txt
@@ -15,7 +15,7 @@ Connection Troubleshooting
    :values: reference
 
 .. meta::
-  :keyworrds: code example, disconnected, deployment
+  :keywords: code example, disconnected, deployment
 
 .. sharedinclude:: dbx/connection-troubleshooting.rst
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-rust/blob/master/REVIEWING.md)

JIRA - None
Staging - https://preview-mongodbcchomongodb.gatsbyjs.io/rust/011824-typo-fix/connection-troubleshooting/ (no changes)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
