### PR TITLE
DOCSP-36574: Update feedback widget name

### DIFF
--- a/source/includes/quick-start/troubleshoot.rst
+++ b/source/includes/quick-start/troubleshoot.rst
@@ -1,6 +1,6 @@
 .. note::
-    
-   If you run into issues on this step, ask for help in the 
+
+   If you run into issues on this step, ask for help in the
    :community-forum:`MongoDB Community Forums <tag/rust/>`
-   or submit feedback by using the :guilabel:`Share Feedback` 
+   or submit feedback by using the :guilabel:`Rate this page`
    tab on the right or bottom right side of this page.


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-rust/blob/master/REVIEWING.md)

Note: The feedback widget hasn't been updated in the staging environment.

JIRA - <https://jira.mongodb.org/browse/DOCSP-36574>
Staging:
[Quick Start > Download and Install](https://preview-mongodbcchomongodb.gatsbyjs.io/node/DOCSP-36573-feedback-widget-title/quick-start/download-and-install/)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
