### PR TITLE
DOCSP-39854: Remove async-std runtime support

### DIFF
--- a/source/fundamentals/runtimes.txt
+++ b/source/fundamentals/runtimes.txt
@@ -50,10 +50,7 @@ Configure the Asynchronous Runtime
 ----------------------------------
 
 The driver uses the ``tokio`` runtime by default, so you can use this runtime without specifying any
-feature flags in your project's ``Cargo.toml`` file. You can also explicitly choose the ``tokio`` runtime
-by adding the ``"tokio-runtime"`` feature flag to the ``mongodb`` dependency. For an example that
-specifies the ``"tokio-runtime"`` feature flag, see the :ref:`rust-runtimes-configure-both` section
-of this guide.
+feature flags in your project's ``Cargo.toml`` file.
 
 .. tip::
 

--- a/source/fundamentals/runtimes.txt
+++ b/source/fundamentals/runtimes.txt
@@ -27,8 +27,8 @@ runtime.
    
    If your application uses the ``async-std`` runtime, you can start a ``tokio`` runtime in the same
    application by creating a ``Runtime`` struct instance and wrapping driver operations with the ``Runtime::spawn()``
-   method. For an example that instantiates a ``Runtime`` and calls the ``spawn()`` method, see the `API Documentation
-   <{+api+}/struct.Runtime.html#examples-2>`__.
+   method. For an example that instantiates a ``Runtime`` and calls the ``spawn()`` method, see the `tokio documentation
+   <https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#examples-2>`__.
 
 The driver also includes a synchronous API for use cases that require blocking, or when parallelism
 is not necessary. You can select the synchronous API by adding feature flags to the ``mongodb`` dependency

--- a/source/fundamentals/runtimes.txt
+++ b/source/fundamentals/runtimes.txt
@@ -24,10 +24,12 @@ runtime.
 
    Beginning in {+driver-short+} v3.0, the ``tokio`` runtime is the only asynchronous runtime crate that
    the driver supports. Previous versions of the driver also support the ``async-std`` runtime crate.
-   
    If your application uses the ``async-std`` runtime, you can start a ``tokio`` runtime in the same
    application by creating a ``Runtime`` struct instance and wrapping driver operations with the ``Runtime::spawn()``
-   method. For an example that instantiates a ``Runtime`` and calls the ``spawn()`` method, see the `tokio documentation
+   method. Ensure that you use the same ``Runtime`` instance for instantiating a ``Client`` and calling
+   driver methods on that ``Client`` instance.
+   
+   For an example that instantiates a ``Runtime`` and calls the ``spawn()`` method, see the `tokio documentation
    <https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#examples-2>`__.
 
 The driver also includes a synchronous API for use cases that require blocking, or when parallelism

--- a/source/fundamentals/runtimes.txt
+++ b/source/fundamentals/runtimes.txt
@@ -39,7 +39,7 @@ This guide includes the following sections:
   ``sync`` and ``tokio-sync`` synchronous runtimes
 
 - :ref:`rust-runtimes-configure-both` shows how to enable both the asynchronous and synchronous
-   runtimes APIs in your application
+  runtimes APIs in your application
 
 - :ref:`rust-addtl-info-runtimes` provides links to resources and API documentation for types
   and methods mentioned in this guide

--- a/source/fundamentals/runtimes.txt
+++ b/source/fundamentals/runtimes.txt
@@ -14,47 +14,37 @@ Overview
 --------
 
 In this guide, you can learn about the {+driver-short+}'s :ref:`asynchronous <rust-runtimes-configure-async>`
-and :ref:`synchronous <rust-runtimes-configure-sync>` APIs.
-This guide explains how to enable the available APIs and structure your code to use each.
+and :ref:`synchronous <rust-runtimes-configure-sync>` APIs. This guide explains how to enable the available APIs
+and structure your code to use each.
 
-The {+driver-short+} supports ``tokio`` and ``async-std``, two popular asynchronous runtime crates.
-By default, the driver uses the ``tokio`` asynchronous runtime, but you can select a specific runtime
-by adding feature flags to the ``mongodb`` dependency in your ``Cargo.toml`` file.
+The {+driver-short+} supports the ``tokio`` asynchronous runtime crate, which is the default
+runtime.
 
-The driver also includes a synchronous API for use cases that require blocking, or when parallelism is not necessary.
-You can select the synchronous API by adding feature flags to the ``mongodb`` dependency in your ``Cargo.toml`` file.
+.. important::
+
+   Beginning in {+driver-short+} v3.0, the ``tokio`` runtime is the only asynchronous runtime crate that
+   the driver supports. Previous versions of the driver also support the ``async-std`` runtime. To enable
+   the ``async-std`` runtime, you must use an earlier version of the {+driver-short+}.
+
+The driver also includes a synchronous API for use cases that require blocking, or when parallelism
+is not necessary. You can select the synchronous API by adding feature flags to the ``mongodb`` dependency
+in your ``Cargo.toml`` file.
 
 .. _rust-runtimes-configure-async:
 
 Configure the Asynchronous Runtime
 ----------------------------------
 
-The driver uses the ``tokio`` runtime by default.
-You can explicitly choose a runtime by adding the ``"tokio-runtime"`` or ``"async-std-runtime"``
-feature flags to the ``mongodb`` dependency.
+The driver uses the ``tokio`` runtime by default, so you can use this runtime without specifying any
+feature flags in your project's ``Cargo.toml`` file. You can also explicitly choose the ``tokio`` runtime
+by adding the ``"tokio-runtime"`` feature flag to the ``mongodb`` dependency, as shown in the following
+code:
 
-Select from the following tabs to see how to add feature flags for each corresponding crate:
+.. code-block:: toml
 
-.. tabs::
-
-   .. tab:: tokio
-      :tabid: asynchronous-api-tokio
-
-      .. code-block:: toml
-
-         [dependencies.mongodb]
-         version = "{+version+}"
-         features = ["tokio-runtime"]
-
-   .. tab:: async-std
-      :tabid: asynchronous-api-async-std
-
-      .. code-block:: toml
-
-         [dependencies.mongodb]
-         version = "{+version+}"
-         default-features = false
-         features = ["async-std"]
+   [dependencies.mongodb]
+   version = "{+version+}"
+   features = ["tokio-runtime"]
 
 For more information on installing the driver and adding feature flags,
 see the :ref:`rust-quick-start-download-and-install` step of the Quick Start.

--- a/source/fundamentals/runtimes.txt
+++ b/source/fundamentals/runtimes.txt
@@ -23,8 +23,8 @@ runtime.
 .. important::
 
    Beginning in {+driver-short+} v3.0, the ``tokio`` runtime is the only asynchronous runtime crate that
-   the driver supports. Previous versions of the driver also support the ``async-std`` runtime. To enable
-   the ``async-std`` runtime, you must use an earlier version of the {+driver-short+}.
+   the driver supports. Previous versions of the driver also support the ``async-std`` runtime crate. To
+   enable the ``async-std`` runtime, you must use a version of the {+driver-short+} that precedes v3.0.
 
 The driver also includes a synchronous API for use cases that require blocking, or when parallelism
 is not necessary. You can select the synchronous API by adding feature flags to the ``mongodb`` dependency

--- a/source/fundamentals/runtimes.txt
+++ b/source/fundamentals/runtimes.txt
@@ -30,6 +30,20 @@ The driver also includes a synchronous API for use cases that require blocking, 
 is not necessary. You can select the synchronous API by adding feature flags to the ``mongodb`` dependency
 in your ``Cargo.toml`` file.
 
+This guide includes the following sections:
+
+- :ref:`rust-runtimes-configure-async` shows how to configure your application to use the
+  ``tokio`` asynchronous runtime
+
+- :ref:`rust-runtimes-configure-sync` shows how to configure your application to use the
+  ``sync`` and ``tokio-sync`` synchronous runtimes
+
+- :ref:`rust-runtimes-configure-both` shows how to enable both the asynchronous and synchronous
+   runtimes APIs in your application
+
+- :ref:`rust-addtl-info-runtimes` provides links to resources and API documentation for types
+  and methods mentioned in this guide
+
 .. _rust-runtimes-configure-async:
 
 Configure the Asynchronous Runtime
@@ -37,17 +51,14 @@ Configure the Asynchronous Runtime
 
 The driver uses the ``tokio`` runtime by default, so you can use this runtime without specifying any
 feature flags in your project's ``Cargo.toml`` file. You can also explicitly choose the ``tokio`` runtime
-by adding the ``"tokio-runtime"`` feature flag to the ``mongodb`` dependency, as shown in the following
-code:
+by adding the ``"tokio-runtime"`` feature flag to the ``mongodb`` dependency. For an example that
+specifies the ``"tokio-runtime"`` feature flag, see the :ref:`rust-runtimes-configure-both` section
+of this guide.
 
-.. code-block:: toml
+.. tip::
 
-   [dependencies.mongodb]
-   version = "{+version+}"
-   features = ["tokio-runtime"]
-
-For more information on installing the driver and adding feature flags,
-see the :ref:`rust-quick-start-download-and-install` step of the Quick Start.
+   For more information on installing the driver and adding feature flags,
+   see the :ref:`rust-quick-start-download-and-install` step of the Quick Start.
 
 Tokio Runtime Example
 ~~~~~~~~~~~~~~~~~~~~~
@@ -103,6 +114,8 @@ When the ``insert_one`` method runs inside the ``for`` loop, the driver waits fo
    :language: rust
    :dedent:
 
+.. _rust-runtimes-configure-both:
+
 Use Both Asynchronous and Synchronous APIs
 ------------------------------------------
 
@@ -119,6 +132,8 @@ For example, to enable both ``tokio`` runtimes, you can add the ``tokio`` depend
    [dependencies.mongodb]
    version = "{+version+}"
    features = ["tokio-sync"]
+
+.. _rust-addtl-info-runtimes:
 
 Additional Information
 ----------------------

--- a/source/fundamentals/runtimes.txt
+++ b/source/fundamentals/runtimes.txt
@@ -25,9 +25,10 @@ runtime.
    Beginning in {+driver-short+} v3.0, the ``tokio`` runtime is the only asynchronous runtime crate that
    the driver supports. Previous versions of the driver also support the ``async-std`` runtime crate.
    
-   If your application uses the ``async-std`` runtime, you can start a ``tokio`` runtime in the same application
-   for {+driver-short+} operations. Specify the ``#[tokio::main]`` attribute above functions that run
-   driver operations.
+   If your application uses the ``async-std`` runtime, you can start a ``tokio`` runtime in the same
+   application by creating a ``Runtime`` struct instance and wrapping driver operations with the ``Runtime::spawn()``
+   method. For an example that instantiates a ``Runtime`` and calls the ``spawn()`` method, see the `API Documentation
+   <{+api+}/struct.Runtime.html#examples-2>`__.
 
 The driver also includes a synchronous API for use cases that require blocking, or when parallelism
 is not necessary. You can select the synchronous API by adding feature flags to the ``mongodb`` dependency

--- a/source/fundamentals/runtimes.txt
+++ b/source/fundamentals/runtimes.txt
@@ -23,8 +23,11 @@ runtime.
 .. important::
 
    Beginning in {+driver-short+} v3.0, the ``tokio`` runtime is the only asynchronous runtime crate that
-   the driver supports. Previous versions of the driver also support the ``async-std`` runtime crate. To
-   enable the ``async-std`` runtime, you must use a version of the {+driver-short+} that precedes v3.0.
+   the driver supports. Previous versions of the driver also support the ``async-std`` runtime crate.
+   
+   If your application uses the ``async-std`` runtime, you can start a ``tokio`` runtime in the same application
+   for {+driver-short+} operations. Specify the ``#[tokio::main]`` attribute above functions that run
+   driver operations.
 
 The driver also includes a synchronous API for use cases that require blocking, or when parallelism
 is not necessary. You can select the synchronous API by adding feature flags to the ``mongodb`` dependency

--- a/source/fundamentals/runtimes.txt
+++ b/source/fundamentals/runtimes.txt
@@ -50,12 +50,12 @@ Configure the Asynchronous Runtime
 ----------------------------------
 
 The driver uses the ``tokio`` runtime by default, so you can use this runtime without specifying any
-feature flags in your project's ``Cargo.toml`` file.
+feature flags in your project's ``Cargo.toml`` file. 
 
-.. tip::
-
-   For more information on installing the driver and adding feature flags,
-   see the :ref:`rust-quick-start-download-and-install` step of the Quick Start.
+You can explicitly choose the ``tokio`` runtime by adding the ``"tokio-runtime"`` feature flag to
+the ``mongodb`` dependency. For more information on installing the driver and adding feature flags,
+including an example that specifies the ``"tokio-runtime"`` feature flag, see the
+:ref:`rust-quick-start-download-and-install` step of the Quick Start.
 
 Tokio Runtime Example
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-rust/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-39854
Staging - https://preview-mongodbnorareidy.gatsbyjs.io/rust/DOCSP-39854-tokio-runtime/fundamentals/runtimes/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
