### PR TITLE
DOCSP-39860: Read/write concern helper methods

### DIFF
--- a/source/fundamentals/gridfs.txt
+++ b/source/fundamentals/gridfs.txt
@@ -146,7 +146,8 @@ fields:
    * - | ``write_concern()``
      - | ``WriteConcern::w()``,
        | ``WriteConcern::w_timeout()``,
-       | ``WriteConcern::journal()``
+       | ``WriteConcern::journal()``,
+       | ``WriteConcern::majority()``
      - | Specifies the bucket's write concern, which is set to the database's write concern by default
 
    * - ``read_concern()``

--- a/source/fundamentals/gridfs.txt
+++ b/source/fundamentals/gridfs.txt
@@ -144,17 +144,17 @@ fields:
      - Specifies the chunk size used to break the file into chunks, which is 255 KB by default
 
    * - | ``write_concern()``
-     - | ``WriteConcern::w``,
-       | ``WriteConcern::w_timeout``,
-       | ``WriteConcern::journal``
+     - | ``WriteConcern::w()``,
+       | ``WriteConcern::w_timeout()``,
+       | ``WriteConcern::journal()``
      - | Specifies the bucket's write concern, which is set to the database's write concern by default
 
    * - ``read_concern()``
-     - ``ReadConcernLevel::Local``,
-       ``ReadConcernLevel::Majority``,
-       ``ReadConcernLevel::Linearizable``,
-       ``ReadConcernLevel::Available``,
-       ``ReadConcernLevel::Snapshot``
+     - ``ReadConcern::local()``,
+       ``ReadConcern::majority()``,
+       ``ReadConcern::linearizable()``,
+       ``ReadConcern::available()``,
+       ``ReadConcern::snapshot()``
      - Specifies the bucket's read concern, which is set to the database's read concern by default
 
    * - | ``selection_criteria()``


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-rust/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-39860
Staging - https://preview-mongodbnorareidy.gatsbyjs.io/rust/DOCSP-39860-read-write-concern-methods/fundamentals/gridfs/

Note: the GridFS guide is the only page that this change applies to; all other examples already use helper methods to specify read/write concerns

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
