### PR TITLE
DOCSP-44852: Remove reference to page rating in bottom right

### DIFF
--- a/source/includes/quick-start/troubleshoot.rst
+++ b/source/includes/quick-start/troubleshoot.rst
@@ -1,6 +1,4 @@
 .. note::
 
    If you run into issues on this step, ask for help in the
-   :community-forum:`MongoDB Community Forums <tag/rust/>`
-   or submit feedback by using the :guilabel:`Rate this page`
-   tab on the right or bottom right side of this page.
+   :community-forum:`MongoDB Community Forums <tag/rust/>`.


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-rust/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-44852>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
