### PR TITLE
DOCSP-44859: Add delete_one() example

### DIFF
--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -152,8 +152,40 @@ which describes the number of documents deleted. If no documents match
 the query filter you specified, the delete operation does
 not remove any documents, and the value of ``deleted_count`` is ``0``.
 
-delete_many() Example
-~~~~~~~~~~~~~~~~~~~~~
+Delete Examples
+---------------
+
+This section provides code examples for the following delete operations:
+
+- :ref:`delete_one() <rust-delete-one-ex>`
+- :ref:`delete_many() <rust-delete-many-ex>`
+
+.. _rust-delete-one-ex:
+
+Delete One Example
+~~~~~~~~~~~~~~~~~~
+
+The following example uses the ``delete_one()`` method to delete a document
+that has a ``item`` value of ``"placemat"``:
+
+.. io-code-block::
+
+   .. input:: /includes/fundamentals/code-snippets/crud/delete.rs
+      :start-after: begin-delete-one
+      :end-before: end-delete-one
+      :language: rust
+      :dedent:
+
+   .. output::
+      :language: console
+      :visible: false
+
+      Deleted documents: 1
+
+.. _rust-delete-many-ex:
+
+Delete Many Example
+~~~~~~~~~~~~~~~~~~~
 
 This example performs the following actions:
 
@@ -163,12 +195,11 @@ This example performs the following actions:
 - Chains the ``hint()`` method to ``delete_many()`` to use the ``_id_`` index as the hint
   for the delete operation
 
-
 .. io-code-block::
 
    .. input:: /includes/fundamentals/code-snippets/crud/delete.rs
-      :start-after: begin-delete
-      :end-before: end-delete
+      :start-after: begin-delete-many
+      :end-before: end-delete-many
       :language: rust
       :dedent:
 

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -169,7 +169,7 @@ Delete One Example
 ~~~~~~~~~~~~~~~~~~
 
 The following example uses the ``delete_one()`` method to delete a document
-that has a ``item`` value of ``"placemat"``:
+that has an ``item`` value of ``"placemat"``:
 
 .. io-code-block::
 

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -31,6 +31,9 @@ This guide includes the following sections:
 - :ref:`Delete Operations <rust-delete-operations>` describes how to use the
   driver to execute delete operations
 
+- :ref:`Delete Examples <rust-delete-operations>` provides code examples
+  for the delete operations
+
 - :ref:`Additional Information <rust-crud-del-addtl-info>`
   provides links to resources and API documentation for types
   and methods mentioned in this guide

--- a/source/includes/fundamentals/code-snippets/crud/delete.rs
+++ b/source/includes/fundamentals/code-snippets/crud/delete.rs
@@ -9,7 +9,14 @@ async fn main() -> mongodb::error::Result<()> {
 
     let my_coll: Collection<Document> = client.database("db").collection("inventory");
 
-    // begin-delete
+    // begin-delete-one
+    let filter = doc! { "item": "placemat" };
+
+    let res = my_coll.delete_one(filter).await?;
+    println!("Deleted documents: {}", res.deleted_count);
+    // end-delete-one
+
+    // begin-delete-many
     let filter = doc! { "category": "garden" };
     let hint = Hint::Name("_id_".to_string());
 
@@ -18,7 +25,7 @@ async fn main() -> mongodb::error::Result<()> {
         .hint(hint)
         .await?;
     println!("Deleted documents: {}", res.deleted_count);
-    // end-delete
+    // end-delete-many
 
     // begin-options
     let res = my_coll


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-rust/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-44859
Staging - https://deploy-preview-156--docs-rust.netlify.app/fundamentals/crud/write-operations/delete/

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
